### PR TITLE
test(searchService): Add unit tests for searchService module

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,11 @@
   },
   "jest": {
     "transform": {
-      "^.+\\.(ts|tsx|js|jsx)$": "ts-jest"
+      "^.+\\.(ts|tsx|js|jsx)$": "ts-jest",
+      "testMatch": [
+      "**/__tests__/**/*.test.ts",
+      "**/?(*.)+(spec|test).ts"
+    ]
     },
     "testEnvironment": "jsdom",
     "moduleNameMapper": {

--- a/src/services/recordService.test.ts
+++ b/src/services/recordService.test.ts
@@ -1,69 +1,189 @@
-import { getUserId, getSessionKey } from '../services/userService';
+import { recordClicks, updateRecordClicks, recordSequence, userClick, deleteRecording, updateRecording, profanityCheck, saveClickData, postRecordSequenceData, recordUserClickData } from './recordService';
+import { getSessionKey, getUserId } from './userService';
+import { ENDPOINT } from '../config/endpoints';
+import { REST } from '.';
 import { getFromStore } from '../util';
 import { CONFIG } from '../config';
 
-jest.mock('../util');
+jest.mock('./userService', () => ({
+  getSessionKey: jest.fn(),
+  getUserId: jest.fn(),
+}));
 
-describe('userService - Additional Tests', () => {
+jest.mock('.', () => ({
+  REST: {
+    apiCal: jest.fn(),
+  },
+}));
+
+jest.mock('../util', () => ({
+  getFromStore: jest.fn(),
+}));
+
+describe('recordService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('getUserId - Additional Tests', () => {
-    it('should handle non-object user session data', async () => {
-      (getFromStore as jest.Mock).mockResolvedValue('not an object');
-      const result = await getUserId();
-      expect(result).toBeNull();
-    });
+  describe('recordClicks', () => {
+    it('should call REST.apiCal with the correct parameters', async () => {
+      const mockRequest = { id: 'click123' };
+      const mockSessionKey = 'session123';
+      (getSessionKey as jest.Mock).mockResolvedValueOnce(mockSessionKey);
 
-    it('should handle user session data with null authdata', async () => {
-      (getFromStore as jest.Mock).mockResolvedValue({ authdata: null });
-      const result = await getUserId();
-      expect(result).toBeNull();
-    });
+      await recordClicks(mockRequest);
 
-    it('should handle user session data with undefined authdata', async () => {
-      (getFromStore as jest.Mock).mockResolvedValue({ authdata: undefined });
-      const result = await getUserId();
-      expect(result).toBeNull();
-    });
-
-    it('should handle user session data with non-object authdata', async () => {
-      (getFromStore as jest.Mock).mockResolvedValue({ authdata: 'not an object' });
-      const result = await getUserId();
-      expect(result).toBeNull();
+      expect(getSessionKey).toHaveBeenCalled();
+      expect(REST.apiCal).toHaveBeenCalledWith({
+        url: ENDPOINT.Record,
+        method: 'POST',
+        body: {
+          ...mockRequest,
+          sessionid: mockSessionKey,
+        },
+      });
     });
   });
 
-  describe('getSessionKey - Additional Tests', () => {
-    it('should handle non-object user session data', async () => {
-      (getFromStore as jest.Mock).mockResolvedValue('not an object');
-      const result = await getSessionKey();
-      expect(result).toBeNull();
-    });
+  describe('updateRecordClicks', () => {
+    it('should call REST.apiCal with the correct parameters', async () => {
+      const mockRequest = { id: 'click123' };
+      const mockSessionKey = 'session123';
+      (getSessionKey as jest.Mock).mockResolvedValueOnce(mockSessionKey);
 
-    it('should handle user session data with null sessionkey', async () => {
-      (getFromStore as jest.Mock).mockResolvedValue({ sessionkey: null });
-      const result = await getSessionKey();
-      expect(result).toBeNull();
-    });
+      await updateRecordClicks(mockRequest);
 
-    it('should handle user session data with undefined sessionkey', async () => {
-      (getFromStore as jest.Mock).mockResolvedValue({ sessionkey: undefined });
-      const result = await getSessionKey();
-      expect(result).toBeNull();
+      expect(getSessionKey).toHaveBeenCalled();
+      expect(REST.apiCal).toHaveBeenCalledWith({
+        url: ENDPOINT.UpdateRecord,
+        method: 'POST',
+        body: {
+          ...mockRequest,
+          sessionid: mockSessionKey,
+        },
+      });
     });
   });
 
-  describe('Error Handling - Additional Tests', () => {
-    it('should handle getFromStore throwing an error in getUserId', async () => {
-      (getFromStore as jest.Mock).mockRejectedValue(new Error('Storage error'));
-      await expect(getUserId()).rejects.toThrow('Storage error');
-    });
+  describe('recordSequence', () => {
+    it('should call REST.apiCal with the correct parameters', async () => {
+      const mockRequest = { id: 'sequence123' };
+      const mockUserId = 'user123';
+      (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
 
-    it('should handle getFromStore throwing an error in getSessionKey', async () => {
-      (getFromStore as jest.Mock).mockRejectedValue(new Error('Storage error'));
-      await expect(getSessionKey()).rejects.toThrow('Storage error');
+      await recordSequence(mockRequest);
+
+      expect(getUserId).toHaveBeenCalled();
+      expect(REST.apiCal).toHaveBeenCalledWith({
+        url: ENDPOINT.RecordSequence,
+        method: 'POST',
+        body: {
+          ...mockRequest,
+          usersessionid: mockUserId,
+        },
+      });
+    });
+  });
+
+  describe('userClick', () => {
+    it('should call REST.apiCal with the correct parameters', async () => {
+      const mockRequest = { id: 'click123' };
+      const mockUserId = 'user123';
+      (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
+
+      await userClick(mockRequest);
+
+      expect(getUserId).toHaveBeenCalled();
+      expect(REST.apiCal).toHaveBeenCalledWith({
+        url: ENDPOINT.UserClick,
+        method: 'PUT',
+        body: {
+          ...mockRequest,
+          usersessionid: mockUserId,
+          clickedname: window.location.host,
+        },
+      });
+    });
+  });
+
+  describe('deleteRecording', () => {
+    it('should call REST.apiCal with the correct parameters', async () => {
+      const mockRequest = { id: 'sequence123' };
+      const mockUserId = 'user123';
+      (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
+
+      await deleteRecording(mockRequest);
+
+      expect(getUserId).toHaveBeenCalled();
+      expect(REST.apiCal).toHaveBeenCalledWith({
+        url: ENDPOINT.DeleteSequence,
+        method: 'POST',
+        body: {
+          ...mockRequest,
+          usersessionid: mockUserId,
+        },
+      });
+    });
+  });
+
+  describe('updateRecording', () => {
+    it('should call REST.apiCal with the correct parameters', async () => {
+      const mockRequest = { id: 'sequence123' };
+      const mockUserId = 'user123';
+      (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
+
+      await updateRecording(mockRequest);
+
+      expect(getUserId).toHaveBeenCalled();
+      expect(REST.apiCal).toHaveBeenCalledWith({
+        url: ENDPOINT.updateRecordSequence,
+        method: 'POST',
+        body: {
+          ...mockRequest,
+          usersessionid: mockUserId,
+        },
+      });
+    });
+  });
+
+  describe('profanityCheck', () => {
+    it('should call REST.apiCal with the correct parameters', async () => {
+      const mockRequest = 'test text';
+
+      await profanityCheck(mockRequest);
+
+      expect(REST.apiCal).toHaveBeenCalledWith({
+        url: ENDPOINT.ProfanityCheck,
+        method: 'POST',
+        body: mockRequest,
+        headers: expect.any(Headers),
+      });
+    });
+  });
+
+  describe('saveClickData', () => {
+    it('should return false if screen size is not available', async () => {
+      const mockNode = document.createElement('div');
+      const mockText = 'test text';
+      const mockMeta = {};
+
+      const result = await saveClickData(mockNode, mockText, mockMeta);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('postRecordSequenceData', () => {
+    it('should call recordSequence with the correct parameters', async () => {
+      const mockRequest = { id: 'sequence123' };
+      const mockUserClickNodes = [{ id: 'click1' }, { id: 'click2' }];
+      (getFromStore as jest.Mock).mockReturnValueOnce(mockUserClickNodes);
+
+      await postRecordSequenceData(mockRequest);
+
+      expect(getFromStore).toHaveBeenCalled();
+      expect(recordSequence).toHaveBeenCalledWith(mockRequest);
     });
   });
 });
+

--- a/src/services/recordService.test.ts
+++ b/src/services/recordService.test.ts
@@ -5,6 +5,10 @@ import { REST } from '.';
 import { getFromStore } from '../util';
 import { CONFIG } from '../config';
 
+/**
+ * Mocks the `userService` module, providing jest.fn() implementations for the `getSessionKey` and `getUserId` functions.
+ * This is used for testing purposes to isolate the `recordService` module from the actual implementation of the `userService` module.
+ */
 jest.mock('./userService', () => ({
   getSessionKey: jest.fn(),
   getUserId: jest.fn(),
@@ -19,6 +23,9 @@ jest.mock('.', () => ({
   },
 }));
 
+/**
+ * Mocks the `getFromStore` function from the `../util` module for testing purposes.
+ */
 jest.mock('../util', () => ({
   getFromStore: jest.fn(),
 }));

--- a/src/services/recordService.test.ts
+++ b/src/services/recordService.test.ts
@@ -11,6 +11,9 @@ jest.mock('./userService', () => ({
 }));
 
 jest.mock('.', () => ({
+  /**
+   * A mock implementation of the REST API client, used for testing purposes.
+   */
   REST: {
     apiCal: jest.fn(),
   },
@@ -20,159 +23,205 @@ jest.mock('../util', () => ({
   getFromStore: jest.fn(),
 }));
 
+/**
+ * Tests for the `recordService` module, which handles various recording-related functionality.
+ */
 describe('recordService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('recordClicks', () => {
-    it('should call REST.apiCal with the correct parameters', async () => {
-      const mockRequest = { id: 'click123' };
-      const mockSessionKey = 'session123';
-      (getSessionKey as jest.Mock).mockResolvedValueOnce(mockSessionKey);
+  // Test suite for the recordClicks function
+describe('recordClicks', () => {
+  // Test case to verify REST.apiCal is called with correct parameters
+  it('should call REST.apiCal with the correct parameters', async () => {
+    // Mock data setup
+    const mockRequest = { id: 'click123' };
+    const mockSessionKey = 'session123';
+    (getSessionKey as jest.Mock).mockResolvedValueOnce(mockSessionKey);
 
-      await recordClicks(mockRequest);
+    // Call the function being tested
+    await recordClicks(mockRequest);
 
-      expect(getSessionKey).toHaveBeenCalled();
-      expect(REST.apiCal).toHaveBeenCalledWith({
-        url: ENDPOINT.Record,
-        method: 'POST',
-        body: {
-          ...mockRequest,
-          sessionid: mockSessionKey,
-        },
-      });
+    // Assertions
+    expect(getSessionKey).toHaveBeenCalled();
+    expect(REST.apiCal).toHaveBeenCalledWith({
+      url: ENDPOINT.Record,
+      method: 'POST',
+      body: {
+        ...mockRequest,
+        sessionid: mockSessionKey,
+      },
     });
   });
+});
 
-  describe('updateRecordClicks', () => {
-    it('should call REST.apiCal with the correct parameters', async () => {
-      const mockRequest = { id: 'click123' };
-      const mockSessionKey = 'session123';
-      (getSessionKey as jest.Mock).mockResolvedValueOnce(mockSessionKey);
+// Test suite for the updateRecordClicks function
+describe('updateRecordClicks', () => {
+  // Test case to verify REST.apiCal is called with correct parameters
+  it('should call REST.apiCal with the correct parameters', async () => {
+    // Mock data setup
+    const mockRequest = { id: 'click123' };
+    const mockSessionKey = 'session123';
+    (getSessionKey as jest.Mock).mockResolvedValueOnce(mockSessionKey);
 
-      await updateRecordClicks(mockRequest);
+    // Call the function being tested
+    await updateRecordClicks(mockRequest);
 
-      expect(getSessionKey).toHaveBeenCalled();
-      expect(REST.apiCal).toHaveBeenCalledWith({
-        url: ENDPOINT.UpdateRecord,
-        method: 'POST',
-        body: {
-          ...mockRequest,
-          sessionid: mockSessionKey,
-        },
-      });
+    // Assertions
+    expect(getSessionKey).toHaveBeenCalled();
+    expect(REST.apiCal).toHaveBeenCalledWith({
+      url: ENDPOINT.UpdateRecord,
+      method: 'POST',
+      body: {
+        ...mockRequest,
+        sessionid: mockSessionKey,
+      },
     });
   });
+});
 
-  describe('recordSequence', () => {
-    it('should call REST.apiCal with the correct parameters', async () => {
-      const mockRequest = { id: 'sequence123' };
-      const mockUserId = 'user123';
-      (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
+// Test suite for the recordSequence function
+describe('recordSequence', () => {
+  // Test case to verify REST.apiCal is called with correct parameters
+  it('should call REST.apiCal with the correct parameters', async () => {
+    // Mock data setup
+    const mockRequest = { id: 'sequence123' };
+    const mockUserId = 'user123';
+    (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
 
-      await recordSequence(mockRequest);
+    // Call the function being tested
+    await recordSequence(mockRequest);
 
-      expect(getUserId).toHaveBeenCalled();
-      expect(REST.apiCal).toHaveBeenCalledWith({
-        url: ENDPOINT.RecordSequence,
-        method: 'POST',
-        body: {
-          ...mockRequest,
-          usersessionid: mockUserId,
-        },
-      });
+    // Assertions
+    expect(getUserId).toHaveBeenCalled();
+    expect(REST.apiCal).toHaveBeenCalledWith({
+      url: ENDPOINT.RecordSequence,
+      method: 'POST',
+      body: {
+        ...mockRequest,
+        usersessionid: mockUserId,
+      },
     });
   });
+});
 
-  describe('userClick', () => {
-    it('should call REST.apiCal with the correct parameters', async () => {
-      const mockRequest = { id: 'click123' };
-      const mockUserId = 'user123';
-      (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
+  // Test suite for the userClick function
+describe('userClick', () => {
+  // Test case to verify REST.apiCal is called with correct parameters
+  it('should call REST.apiCal with the correct parameters', async () => {
+    // Mock data setup
+    const mockRequest = { id: 'click123' };
+    const mockUserId = 'user123';
+    (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
 
-      await userClick(mockRequest);
+    // Call the function being tested
+    await userClick(mockRequest);
 
-      expect(getUserId).toHaveBeenCalled();
-      expect(REST.apiCal).toHaveBeenCalledWith({
-        url: ENDPOINT.UserClick,
-        method: 'PUT',
-        body: {
-          ...mockRequest,
-          usersessionid: mockUserId,
-          clickedname: window.location.host,
-        },
-      });
+    // Assertions
+    expect(getUserId).toHaveBeenCalled();
+    expect(REST.apiCal).toHaveBeenCalledWith({
+      url: ENDPOINT.UserClick,
+      method: 'PUT',
+      body: {
+        ...mockRequest,
+        usersessionid: mockUserId,
+        clickedname: window.location.host,
+      },
     });
   });
+});
 
-  describe('deleteRecording', () => {
-    it('should call REST.apiCal with the correct parameters', async () => {
-      const mockRequest = { id: 'sequence123' };
-      const mockUserId = 'user123';
-      (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
+// Test suite for the deleteRecording function
+describe('deleteRecording', () => {
+  // Test case to verify REST.apiCal is called with correct parameters
+  it('should call REST.apiCal with the correct parameters', async () => {
+    // Mock data setup
+    const mockRequest = { id: 'sequence123' };
+    const mockUserId = 'user123';
+    (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
 
-      await deleteRecording(mockRequest);
+    // Call the function being tested
+    await deleteRecording(mockRequest);
 
-      expect(getUserId).toHaveBeenCalled();
-      expect(REST.apiCal).toHaveBeenCalledWith({
-        url: ENDPOINT.DeleteSequence,
-        method: 'POST',
-        body: {
-          ...mockRequest,
-          usersessionid: mockUserId,
-        },
-      });
+    // Assertions
+    expect(getUserId).toHaveBeenCalled();
+    expect(REST.apiCal).toHaveBeenCalledWith({
+      url: ENDPOINT.DeleteSequence,
+      method: 'POST',
+      body: {
+        ...mockRequest,
+        usersessionid: mockUserId,
+      },
     });
   });
+});
 
-  describe('updateRecording', () => {
-    it('should call REST.apiCal with the correct parameters', async () => {
-      const mockRequest = { id: 'sequence123' };
-      const mockUserId = 'user123';
-      (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
+// Test suite for the updateRecording function
+describe('updateRecording', () => {
+  // Test case to verify REST.apiCal is called with correct parameters
+  it('should call REST.apiCal with the correct parameters', async () => {
+    // Mock data setup
+    const mockRequest = { id: 'sequence123' };
+    const mockUserId = 'user123';
+    (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
 
-      await updateRecording(mockRequest);
+    // Call the function being tested
+    await updateRecording(mockRequest);
 
-      expect(getUserId).toHaveBeenCalled();
-      expect(REST.apiCal).toHaveBeenCalledWith({
-        url: ENDPOINT.updateRecordSequence,
-        method: 'POST',
-        body: {
-          ...mockRequest,
-          usersessionid: mockUserId,
-        },
-      });
+    // Assertions
+    expect(getUserId).toHaveBeenCalled();
+    expect(REST.apiCal).toHaveBeenCalledWith({
+      url: ENDPOINT.updateRecordSequence,
+      method: 'POST',
+      body: {
+        ...mockRequest,
+        usersessionid: mockUserId,
+      },
     });
   });
+});
 
-  describe('profanityCheck', () => {
-    it('should call REST.apiCal with the correct parameters', async () => {
-      const mockRequest = 'test text';
+  // Test suite for the profanityCheck function
+describe('profanityCheck', () => {
+  // Test case to verify that REST.apiCal is called with correct parameters
+  it('should call REST.apiCal with the correct parameters', async () => {
+    const mockRequest = 'test text';
 
-      await profanityCheck(mockRequest);
+    await profanityCheck(mockRequest);
 
-      expect(REST.apiCal).toHaveBeenCalledWith({
-        url: ENDPOINT.ProfanityCheck,
-        method: 'POST',
-        body: mockRequest,
-        headers: expect.any(Headers),
-      });
+    // Expect REST.apiCal to be called with specific arguments
+    expect(REST.apiCal).toHaveBeenCalledWith({
+      url: ENDPOINT.ProfanityCheck,
+      method: 'POST',
+      body: mockRequest,
+      headers: expect.any(Headers),
     });
   });
+});
 
-  describe('saveClickData', () => {
-    it('should return false if screen size is not available', async () => {
-      const mockNode = document.createElement('div');
-      const mockText = 'test text';
-      const mockMeta = {};
+// Test suite for the saveClickData function
+describe('saveClickData', () => {
+  // Test case to check behavior when screen size is not available
+  it('should return false if screen size is not available', async () => {
+    const mockNode = document.createElement('div');
+    const mockText = 'test text';
+    const mockMeta = {};
 
-      const result = await saveClickData(mockNode, mockText, mockMeta);
+    // Call saveClickData with mock arguments
+    const result = await saveClickData(mockNode, mockText, mockMeta);
 
-      expect(result).toBe(false);
-    });
+    // Expect the function to return false
+    expect(result).toBe(false);
   });
+});
 
+
+  
+
+  /*The test mocks the getFromStore function to return a predefined set of user click nodes
+  * and checks if the recordSequence function is called with the mock request.
+  */
   describe('postRecordSequenceData', () => {
     it('should call recordSequence with the correct parameters', async () => {
       const mockRequest = { id: 'sequence123' };

--- a/src/services/searchService.test.ts
+++ b/src/services/searchService.test.ts
@@ -15,129 +15,170 @@ jest.mock('./index', () => ({
   }
 }));
 
+/**
+ * Clears all mocks after each test suite for the `searchService` module.
+ */
 describe('searchService', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
+});
 
-  describe('fetchSearchResults', () => {
-    it('should call REST.apiCal with the correct parameters', async () => {
-      const mockUserId = '123456789';
-      const mockRequest = {
-        keyword: 'test',
-        page: 1,
-        domain: 'example.com',
-        additionalParams: { foo: 'bar' }
-      };
+  // Test suite for the fetchSearchResults function
+describe('fetchSearchResults', () => {
+  // Test case to verify REST.apiCal is called with correct parameters including additionalParams
+  it('should call REST.apiCal with the correct parameters', async () => {
+    // Mock data setup
+    const mockUserId = '123456789';
+    const mockRequest = {
+      keyword: 'test',
+      page: 1,
+      domain: 'example.com',
+      additionalParams: { foo: 'bar' }
+    };
 
-      jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
-      jest.spyOn(require('./index'), 'REST').mockReturnValue({
-        apiCal: jest.fn(),
-        processArgs: jest.fn().mockReturnValue(ENDPOINT.SearchWithPermissions)
-      });
-
-      await fetchSearchResults(mockRequest);
-
-      expect(REST.processArgs).toHaveBeenCalledWith(ENDPOINT.SearchWithPermissions, {
-        ...mockRequest,
-        userSessionId: mockUserId
-      });
-      expect(REST.apiCal).toHaveBeenCalledWith({
-        url: ENDPOINT.SearchWithPermissions,
-        method: 'GET'
-      });
+    // Mock dependencies
+    jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
+    jest.spyOn(require('./index'), 'REST').mockReturnValue({
+      apiCal: jest.fn(),
+      processArgs: jest.fn().mockReturnValue(ENDPOINT.SearchWithPermissions)
     });
 
-    it('should call REST.apiCal with the correct parameters without additionalParams', async () => {
-      const mockUserId = '123456789';
-      const mockRequest = {
-        keyword: 'test',
-        page: 1,
-        domain: 'example.com'
-      };
+    // Call the function being tested
+    await fetchSearchResults(mockRequest);
 
-      jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
-      jest.spyOn(require('./index'), 'REST').mockReturnValue({
-        apiCal: jest.fn(),
-        processArgs: jest.fn().mockReturnValue(ENDPOINT.Search)
-      });
-
-      await fetchSearchResults(mockRequest);
-
-      expect(REST.processArgs).toHaveBeenCalledWith(ENDPOINT.Search, {
-        ...mockRequest,
-        userSessionId: mockUserId
-      });
-      expect(REST.apiCal).toHaveBeenCalledWith({
-        url: ENDPOINT.Search,
-        method: 'GET'
-      });
+    // Assertions
+    expect(REST.processArgs).toHaveBeenCalledWith(ENDPOINT.SearchWithPermissions, {
+      ...mockRequest,
+      userSessionId: mockUserId
     });
-
-    it('should call recordUserClickData with the correct parameters', async () => {
-      const mockUserId = '123456789';
-      const mockRequest = {
-        keyword: 'test',
-        page: 1,
-        domain: 'example.com',
-        additionalParams: { foo: 'bar' }
-      };
-
-      jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
-      jest.spyOn(require('./index'), 'REST').mockReturnValue({
-        apiCal: jest.fn(),
-        processArgs: jest.fn().mockReturnValue(ENDPOINT.SearchWithPermissions)
-      });
-      jest.spyOn(require('./recordService'), 'recordUserClickData').mockReturnValue(Promise.resolve());
-
-      await fetchSearchResults(mockRequest);
-
-      expect(recordUserClickData).toHaveBeenCalledWith('search', mockRequest.keyword);
+    expect(REST.apiCal).toHaveBeenCalledWith({
+      url: ENDPOINT.SearchWithPermissions,
+      method: 'GET'
     });
   });
 
-  describe('fetchRecord', () => {
-    it('should call REST.apiCal with the correct parameters', async () => {
-      const mockUserId = '123456789';
-      const mockRequest = {
-        id: 'abc123',
-        domain: 'example.com',
-        additionalParams: { foo: 'bar' }
-      };
+  // Test case to verify REST.apiCal is called with correct parameters without additionalParams
+  it('should call REST.apiCal with the correct parameters without additionalParams', async () => {
+    // Mock data setup
+    const mockUserId = '123456789';
+    const mockRequest = {
+      keyword: 'test',
+      page: 1,
+      domain: 'example.com'
+    };
 
-      jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
-
-      await fetchRecord(mockRequest);
-
-      expect(REST.apiCal).toHaveBeenCalledWith({
-        url: `${ENDPOINT.fetchRecord}/withPermissions/${mockRequest.id}?domain=${mockRequest.domain}&additionalParams=${mockRequest.additionalParams}&userSessionId=${mockUserId}`,
-        method: 'GET'
-      });
+    // Mock dependencies
+    jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
+    jest.spyOn(require('./index'), 'REST').mockReturnValue({
+      apiCal: jest.fn(),
+      processArgs: jest.fn().mockReturnValue(ENDPOINT.Search)
     });
 
-    it('should call REST.apiCal with the correct parameters without additionalParams', async () => {
-      const mockUserId = '123456789';
-      const mockRequest = {
-        id: 'abc123',
-        domain: 'example.com'
-      };
+    // Call the function being tested
+    await fetchSearchResults(mockRequest);
 
-      jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
-
-      await fetchRecord(mockRequest);
-
-      expect(REST.apiCal).toHaveBeenCalledWith({
-        url: `${ENDPOINT.fetchRecord}/${mockRequest.id}?domain=${mockRequest.domain}`,
-        method: 'GET'
-      });
+    // Assertions
+    expect(REST.processArgs).toHaveBeenCalledWith(ENDPOINT.Search, {
+      ...mockRequest,
+      userSessionId: mockUserId
     });
-  });
-
-  describe('fetchSpecialNodes', () => {
-    it('should return the specialNodes object', async () => {
-      const result = await fetchSpecialNodes();
-
-      expect(result).toEqual(specialNodes);
+    expect(REST.apiCal).toHaveBeenCalledWith({
+      url: ENDPOINT.Search,
+      method: 'GET'
     });
   });
 });
+
+// Test suite for fetchSearchResults (continued)
+describe('fetchSearchResults', () => {
+  // Test case to verify recordUserClickData is called with correct parameters
+  it('should call recordUserClickData with the correct parameters', async () => {
+    // Mock data setup
+    const mockUserId = '123456789';
+    const mockRequest = {
+      keyword: 'test',
+      page: 1,
+      domain: 'example.com',
+      additionalParams: { foo: 'bar' }
+    };
+
+    // Mock dependencies
+    jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
+    jest.spyOn(require('./index'), 'REST').mockReturnValue({
+      apiCal: jest.fn(),
+      processArgs: jest.fn().mockReturnValue(ENDPOINT.SearchWithPermissions)
+    });
+    jest.spyOn(require('./recordService'), 'recordUserClickData').mockReturnValue(Promise.resolve());
+
+    // Call the function being tested
+    await fetchSearchResults(mockRequest);
+
+    // Assertion
+    expect(recordUserClickData).toHaveBeenCalledWith('search', mockRequest.keyword);
+  });
+});
+
+// Test suite for fetchRecord function
+describe('fetchRecord', () => {
+  // Test case to verify REST.apiCal is called with correct parameters
+  it('should call REST.apiCal with the correct parameters', async () => {
+    // Mock data setup
+    const mockUserId = '123456789';
+    const mockRequest = {
+      id: 'abc123',
+      domain: 'example.com',
+      additionalParams: { foo: 'bar' }
+    };
+
+    // Mock dependency
+    jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
+
+    // Call the function being tested
+    await fetchRecord(mockRequest);
+
+    // Assertion
+    expect(REST.apiCal).toHaveBeenCalledWith({
+      url: `${ENDPOINT.fetchRecord}/withPermissions/${mockRequest.id}?domain=${mockRequest.domain}&additionalParams=${mockRequest.additionalParams}&userSessionId=${mockUserId}`,
+      method: 'GET'
+    });
+  });
+});
+
+// Test suite for fetchRecord (continued)
+describe('fetchRecord', () => {
+  // Test case to verify REST.apiCal is called with correct parameters without additionalParams
+  it('should call REST.apiCal with the correct parameters without additionalParams', async () => {
+    // Mock data setup
+    const mockUserId = '123456789';
+    const mockRequest = {
+      id: 'abc123',
+      domain: 'example.com'
+    };
+
+    // Mock dependency
+    jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
+
+    // Call the function being tested
+    await fetchRecord(mockRequest);
+
+    // Assertion
+    expect(REST.apiCal).toHaveBeenCalledWith({
+      url: `${ENDPOINT.fetchRecord}/${mockRequest.id}?domain=${mockRequest.domain}`,
+      method: 'GET'
+    });
+  });
+});
+
+// Test suite for fetchSpecialNodes function
+describe('fetchSpecialNodes', () => {
+  // Test case to verify fetchSpecialNodes returns the specialNodes object
+  it('should return the specialNodes object', async () => {
+    // Call the function being tested
+    const result = await fetchSpecialNodes();
+
+    // Assertion
+    expect(result).toEqual(specialNodes);
+  });
+});
+

--- a/src/services/searchService.test.ts
+++ b/src/services/searchService.test.ts
@@ -4,16 +4,22 @@ import { REST } from './index';
 import { getUserId } from './userService';
 import { specialNodes } from '../util/specialNodes';
 
-jest.mock('./userService', () => ({
-  getUserId: jest.fn()
-}));
 
-jest.mock('./index', () => ({
-  REST: {
-    apiCal: jest.fn(),
-    processArgs: jest.fn()
-  }
-}));
+// Mocking the userService module by replacing it with a mocked version
+jest.mock('./userService', () => ({
+   getUserId: jest.fn()
+  }));
+  
+  // Mocking the index module by replacing it with a mocked version
+  jest.mock('./index', () => ({
+   REST: {
+  // Mocking the apiCal function inside the REST object
+  apiCal: jest.fn(),
+   // Mocking the processArgs function inside the REST object
+   processArgs: jest.fn()
+   }
+  }));
+
 
 /**
  * Clears all mocks after each test suite for the `searchService` module.
@@ -38,10 +44,15 @@ describe('fetchSearchResults', () => {
     };
 
     // Mock dependencies
+    // Using jest.spyOn to spy on the getUserId function of the userService module and mock it to return a resolved value of mockUserId
     jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
+    
+    // Using jest.spyOn to spy on the REST object of the index module and mock it to return an object with mocked functions
     jest.spyOn(require('./index'), 'REST').mockReturnValue({
-      apiCal: jest.fn(),
-      processArgs: jest.fn().mockReturnValue(ENDPOINT.SearchWithPermissions)
+   // Mocking the apiCal function inside the REST object
+    apiCal: jest.fn(),
+   // Mocking the processArgs function inside the REST object and setting it to return the value ENDPOINT.SearchWithPermissions
+   processArgs: jest.fn().mockReturnValue(ENDPOINT.SearchWithPermissions)
     });
 
     // Call the function being tested
@@ -69,10 +80,15 @@ describe('fetchSearchResults', () => {
     };
 
     // Mock dependencies
+    // Using jest.spyOn to spy on the getUserId function of the userService module and mock it to return a resolved value of mockUserId
     jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
+    
+    // Using jest.spyOn to spy on the REST object of the index module and mock it to return an object with mocked functions
     jest.spyOn(require('./index'), 'REST').mockReturnValue({
-      apiCal: jest.fn(),
-      processArgs: jest.fn().mockReturnValue(ENDPOINT.Search)
+    // Mocking the apiCal function inside the REST object
+    apiCal: jest.fn(),
+    // Mocking the processArgs function inside the REST object and setting it to return the value ENDPOINT.Search
+     processArgs: jest.fn().mockReturnValue(ENDPOINT.Search)
     });
 
     // Call the function being tested
@@ -104,13 +120,19 @@ describe('fetchSearchResults', () => {
     };
 
     // Mock dependencies
-    jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
-    jest.spyOn(require('./index'), 'REST').mockReturnValue({
-      apiCal: jest.fn(),
-      processArgs: jest.fn().mockReturnValue(ENDPOINT.SearchWithPermissions)
-    });
-    jest.spyOn(require('./recordService'), 'recordUserClickData').mockReturnValue(Promise.resolve());
-
+   // Using jest.spyOn to spy on the getUserId function of the userService module and mock it to return a resolved value of mockUserId
+   jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
+   
+   // Using jest.spyOn to spy on the REST object of the index module and mock it to return an object with mocked functions
+   jest.spyOn(require('./index'), 'REST').mockReturnValue({
+   // Mocking the apiCal function inside the REST object
+   apiCal: jest.fn(),
+   // Mocking the processArgs function inside the REST object and setting it to return the value ENDPOINT.SearchWithPermissions
+   processArgs: jest.fn().mockReturnValue(ENDPOINT.SearchWithPermissions)
+   });
+   
+   // Using jest.spyOn to spy on the recordUserClickData function of the recordService module and mock it to return a resolved Promise
+   jest.spyOn(require('./recordService'), 'recordUserClickData').mockReturnValue(Promise.resolve());
     // Call the function being tested
     await fetchSearchResults(mockRequest);
 

--- a/src/services/searchService.test.ts
+++ b/src/services/searchService.test.ts
@@ -1,0 +1,143 @@
+import { fetchSearchResults, fetchRecord, fetchSpecialNodes } from './searchService';
+import { ENDPOINT } from '../config/endpoints';
+import { REST } from './index';
+import { getUserId } from './userService';
+import { specialNodes } from '../util/specialNodes';
+
+jest.mock('./userService', () => ({
+  getUserId: jest.fn()
+}));
+
+jest.mock('./index', () => ({
+  REST: {
+    apiCal: jest.fn(),
+    processArgs: jest.fn()
+  }
+}));
+
+describe('searchService', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fetchSearchResults', () => {
+    it('should call REST.apiCal with the correct parameters', async () => {
+      const mockUserId = '123456789';
+      const mockRequest = {
+        keyword: 'test',
+        page: 1,
+        domain: 'example.com',
+        additionalParams: { foo: 'bar' }
+      };
+
+      jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
+      jest.spyOn(require('./index'), 'REST').mockReturnValue({
+        apiCal: jest.fn(),
+        processArgs: jest.fn().mockReturnValue(ENDPOINT.SearchWithPermissions)
+      });
+
+      await fetchSearchResults(mockRequest);
+
+      expect(REST.processArgs).toHaveBeenCalledWith(ENDPOINT.SearchWithPermissions, {
+        ...mockRequest,
+        userSessionId: mockUserId
+      });
+      expect(REST.apiCal).toHaveBeenCalledWith({
+        url: ENDPOINT.SearchWithPermissions,
+        method: 'GET'
+      });
+    });
+
+    it('should call REST.apiCal with the correct parameters without additionalParams', async () => {
+      const mockUserId = '123456789';
+      const mockRequest = {
+        keyword: 'test',
+        page: 1,
+        domain: 'example.com'
+      };
+
+      jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
+      jest.spyOn(require('./index'), 'REST').mockReturnValue({
+        apiCal: jest.fn(),
+        processArgs: jest.fn().mockReturnValue(ENDPOINT.Search)
+      });
+
+      await fetchSearchResults(mockRequest);
+
+      expect(REST.processArgs).toHaveBeenCalledWith(ENDPOINT.Search, {
+        ...mockRequest,
+        userSessionId: mockUserId
+      });
+      expect(REST.apiCal).toHaveBeenCalledWith({
+        url: ENDPOINT.Search,
+        method: 'GET'
+      });
+    });
+
+    it('should call recordUserClickData with the correct parameters', async () => {
+      const mockUserId = '123456789';
+      const mockRequest = {
+        keyword: 'test',
+        page: 1,
+        domain: 'example.com',
+        additionalParams: { foo: 'bar' }
+      };
+
+      jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
+      jest.spyOn(require('./index'), 'REST').mockReturnValue({
+        apiCal: jest.fn(),
+        processArgs: jest.fn().mockReturnValue(ENDPOINT.SearchWithPermissions)
+      });
+      jest.spyOn(require('./recordService'), 'recordUserClickData').mockReturnValue(Promise.resolve());
+
+      await fetchSearchResults(mockRequest);
+
+      expect(recordUserClickData).toHaveBeenCalledWith('search', mockRequest.keyword);
+    });
+  });
+
+  describe('fetchRecord', () => {
+    it('should call REST.apiCal with the correct parameters', async () => {
+      const mockUserId = '123456789';
+      const mockRequest = {
+        id: 'abc123',
+        domain: 'example.com',
+        additionalParams: { foo: 'bar' }
+      };
+
+      jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
+
+      await fetchRecord(mockRequest);
+
+      expect(REST.apiCal).toHaveBeenCalledWith({
+        url: `${ENDPOINT.fetchRecord}/withPermissions/${mockRequest.id}?domain=${mockRequest.domain}&additionalParams=${mockRequest.additionalParams}&userSessionId=${mockUserId}`,
+        method: 'GET'
+      });
+    });
+
+    it('should call REST.apiCal with the correct parameters without additionalParams', async () => {
+      const mockUserId = '123456789';
+      const mockRequest = {
+        id: 'abc123',
+        domain: 'example.com'
+      };
+
+      jest.spyOn(require('./userService'), 'getUserId').mockResolvedValue(mockUserId);
+
+      await fetchRecord(mockRequest);
+
+      expect(REST.apiCal).toHaveBeenCalledWith({
+        url: `${ENDPOINT.fetchRecord}/${mockRequest.id}?domain=${mockRequest.domain}`,
+        method: 'GET'
+      });
+    });
+  });
+
+  describe('fetchSpecialNodes', () => {
+    it('should return the specialNodes object', async () => {
+      const result = await fetchSpecialNodes();
+
+      expect(result).toEqual(specialNodes);
+    });
+  });
+});

--- a/src/services/translateService.test.ts
+++ b/src/services/translateService.test.ts
@@ -1,0 +1,63 @@
+import { translateText } from './translateService';
+import { CONFIG } from '../config';
+
+jest.mock('../config', () => ({
+  CONFIG: {
+    multilingual: {
+      translate: {
+        provider: 'google',
+        apikey: 'YOUR_API_KEY',
+        apiurl: 'https://translation.googleapis.com/language/translate/v2'
+      }
+    }
+  }
+}));
+
+describe('translateService', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should translate text using Google Translate API', async () => {
+    const text = 'Hello world!';
+    const sourceLang = 'en';
+    const targetLang = 'es';
+
+    const translatedText = await translateText(text, sourceLang, targetLang);
+
+    expect(translatedText).toBeDefined();
+    expect(translatedText).not.toBe(text);
+  });
+
+  it('should handle errors during translation', async () => {
+    const text = 'Hello world!';
+    const sourceLang = 'en';
+    const targetLang = 'es';
+
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      json: jest.fn().mockResolvedValue({
+        error: {
+          code: 400,
+          message: 'Invalid API key'
+        }
+      })
+    });
+
+    try {
+      await translateText(text, sourceLang, targetLang);
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('Failed to translate');
+    }
+  });
+
+  it('should use default target language if not provided', async () => {
+    const text = 'Hello world!';
+    const sourceLang = 'en';
+
+    const translatedText = await translateText(text, sourceLang);
+
+    expect(translatedText).toBeDefined();
+    expect(translatedText).not.toBe(text);
+  });
+});

--- a/src/services/translateService.test.ts
+++ b/src/services/translateService.test.ts
@@ -1,17 +1,25 @@
 import { translateText } from './translateService';
 import { CONFIG } from '../config';
 
+// Mock the '../config' module
 jest.mock('../config', () => ({
+  // Define a mock CONFIG object
   CONFIG: {
+    // Set up the multilingual configuration
     multilingual: {
+      // Configure translation settings
       translate: {
+        // Specify the translation provider as 'google'
         provider: 'google',
+        // Set the API key for authentication (replace with actual key in production)
         apikey: 'YOUR_API_KEY',
+        // Define the URL for the Google Translate API
         apiurl: 'https://translation.googleapis.com/language/translate/v2'
       }
     }
   }
 }));
+
 
 /**
  * Tests the `translateText` function from the `translateService` module.
@@ -49,14 +57,20 @@ describe('translateText', () => {
     const targetLang = 'es';
 
     // Mock the fetch function to simulate an error response
-    jest.spyOn(global, 'fetch').mockResolvedValue({
-      json: jest.fn().mockResolvedValue({
-        error: {
-          code: 400,
-          message: 'Invalid API key'
-        }
-      })
-    });
+   // Create a spy on the global fetch function
+jest.spyOn(global, 'fetch').mockResolvedValue({
+  // Mock the json method of the fetch response
+  json: jest.fn().mockResolvedValue({
+    // Simulate an error response
+    error: {
+      // Set the error code to 400 (Bad Request)
+      code: 400,
+      // Provide an error message indicating an invalid API key
+      message: 'Invalid API key'
+    }
+  })
+});
+
 
     // Call the function being tested and check for error
     try {

--- a/src/services/translateService.test.ts
+++ b/src/services/translateService.test.ts
@@ -13,27 +13,42 @@ jest.mock('../config', () => ({
   }
 }));
 
+/**
+ * Tests the `translateText` function from the `translateService` module.
+ * Verifies that the function can translate text using the Google Translate API,
+ * and handles errors that may occur during the translation process.
+ */
 describe('translateService', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
+});
 
+// Test suite for translateText function
+describe('translateText', () => {
+  // Test case to verify successful translation using Google Translate API
   it('should translate text using Google Translate API', async () => {
+    // Test data setup
     const text = 'Hello world!';
     const sourceLang = 'en';
     const targetLang = 'es';
 
+    // Call the function being tested
     const translatedText = await translateText(text, sourceLang, targetLang);
 
+    // Assertions
     expect(translatedText).toBeDefined();
     expect(translatedText).not.toBe(text);
   });
 
+  // Test case to verify error handling during translation
   it('should handle errors during translation', async () => {
+    // Test data setup
     const text = 'Hello world!';
     const sourceLang = 'en';
     const targetLang = 'es';
 
+    // Mock the fetch function to simulate an error response
     jest.spyOn(global, 'fetch').mockResolvedValue({
       json: jest.fn().mockResolvedValue({
         error: {
@@ -43,6 +58,7 @@ describe('translateService', () => {
       })
     });
 
+    // Call the function being tested and check for error
     try {
       await translateText(text, sourceLang, targetLang);
     } catch (error) {
@@ -51,13 +67,18 @@ describe('translateService', () => {
     }
   });
 
+  // Test case to verify default target language usage
   it('should use default target language if not provided', async () => {
+    // Test data setup
     const text = 'Hello world!';
     const sourceLang = 'en';
 
+    // Call the function being tested
     const translatedText = await translateText(text, sourceLang);
 
+    // Assertions
     expect(translatedText).toBeDefined();
     expect(translatedText).not.toBe(text);
   });
 });
+

--- a/src/services/userService.test.ts
+++ b/src/services/userService.test.ts
@@ -7,13 +7,21 @@ jest.mock('../util', () => ({
   getFromStore: jest.fn(),
 }));
 
+/**
+ * Provides additional tests for the `userService` module.
+ * 
+ * This suite of tests covers edge cases and additional functionality
+ * for the `getUserId` and `getSessionKey` functions.
+ */
 describe('userService', () => {
   beforeEach(() => {
     // Clear all mocks before each test
     jest.clearAllMocks();
   });
+});
 
   describe('getUserId', () => {
+    // Test case to verify getFromStore is called with correct parameters
     it('should return user id when user session data is available', async () => {
       const mockUserData = {
         authdata: {
@@ -26,7 +34,7 @@ describe('userService', () => {
       expect(result).toBe('user123');
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
-
+    // Test case to verify getFromStore is called with correct parameters
     it('should return null when user session data is not available', async () => {
       (getFromStore as jest.Mock).mockResolvedValue(null);
 
@@ -34,7 +42,8 @@ describe('userService', () => {
       expect(result).toBeNull();
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
-
+  });
+ // Test case to verify getFromStore is called with correct parameters
     it('should return null when authdata is missing', async () => {
       const mockUserData = {};
       (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
@@ -42,274 +51,230 @@ describe('userService', () => {
       const result = await getUserId();
       expect(result).toBeNull();
     });
+    
+    // Test suite for getUserId function
+describe('getUserId', () => {
+  // Test case to verify that null is returned when id is missing in authdata
+  it('should return null when id is missing in authdata', async () => {
+    // Mock user data without an id in authdata
+    const mockUserData = {
+      authdata: {},
+    };
+    // Mock the getFromStore function to return the mockUserData
+    (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
 
-    it('should return null when id is missing in authdata', async () => {
-      const mockUserData = {
-        authdata: {},
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getUserId();
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('getSessionKey', () => {
-    it('should return session key when user session data is available', async () => {
-      const mockUserData = {
-        sessionkey: 'session123',
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getSessionKey();
-      expect(result).toBe('session123');
-      expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
-    });
-
-    it('should return null when user session data is not available', async () => {
-      (getFromStore as jest.Mock).mockResolvedValue(null);
-
-      const result = await getSessionKey();
-      expect(result).toBeNull();
-      expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
-    });
-
-    it('should return null when sessionkey is missing', async () => {
-      const mockUserData = {};
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getSessionKey();
-      expect(result).toBeNull();
-    });
-  });
-
-  // Additional edge cases
-  describe('Edge cases', () => {
-    it('should handle empty string user id', async () => {
-      const mockUserData = {
-        authdata: {
-          id: '',
-        },
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getUserId();
-      expect(result).toBe('');
-    });
-
-    it('should handle empty string session key', async () => {
-      const mockUserData = {
-        sessionkey: '',
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getSessionKey();
-      expect(result).toBe('');
-    });
-
-    it('should handle getFromStore throwing an error', async () => {
-      (getFromStore as jest.Mock).mockRejectedValue(new Error('Storage error'));
-
-      await expect(getUserId()).rejects.toThrow('Storage error');
-      await expect(getSessionKey()).rejects.toThrow('Storage error');
-    });
+    // Call the function being tested
+    const result = await getUserId();
+    // Assert that the result is null
+    expect(result).toBeNull();
   });
 });
 
+  // Test suite for getSessionKey function
+describe('getSessionKey', () => {
+  // Test case to verify session key retrieval when user session data is available
+  it('should return session key when user session data is available', async () => {
+    // Mock user data with a session key
+    const mockUserData = {
+      sessionkey: 'session123',
+    };
+    // Mock getFromStore to return the mockUserData
+    (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
 
+    // Call the function being tested
+    const result = await getSessionKey();
+    // Assert the correct session key is returned
+    expect(result).toBe('session123');
+    // Verify getFromStore was called with correct parameters
+    expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
+  });
+
+  // Test case to verify null return when user session data is not available
+  it('should return null when user session data is not available', async () => {
+    // Mock getFromStore to return null
+    (getFromStore as jest.Mock).mockResolvedValue(null);
+
+    // Call the function being tested
+    const result = await getSessionKey();
+    // Assert null is returned
+    expect(result).toBeNull();
+    // Verify getFromStore was called with correct parameters
+    expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
+  });
+
+  // Test case to verify null return when sessionkey is missing
+  it('should return null when sessionkey is missing', async () => {
+    // Mock user data without a sessionkey
+    const mockUserData = {};
+    // Mock getFromStore to return the mockUserData
+    (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
+
+    // Call the function being tested
+    const result = await getSessionKey();
+    // Assert null is returned
+    expect(result).toBeNull();
+  });
+});
+
+// Additional edge cases test suite
+describe('Edge cases', () => {
+  // Test case to handle empty string user id
+  it('should handle empty string user id', async () => {
+    // Mock user data with an empty string id
+    const mockUserData = {
+      authdata: {
+        id: '',
+      },
+    };
+    // Mock getFromStore to return the mockUserData
+    (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
+
+    // Call getUserId function
+    const result = await getUserId();
+    // Assert an empty string is returned
+    expect(result).toBe('');
+  });
+
+  // Test case to handle empty string session key
+  it('should handle empty string session key', async () => {
+    // Mock user data with an empty string sessionkey
+    const mockUserData = {
+      sessionkey: '',
+    };
+    // Mock getFromStore to return the mockUserData
+    (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
+
+    // Call getSessionKey function
+    const result = await getSessionKey();
+    // Assert an empty string is returned
+    expect(result).toBe('');
+  });
+
+  // Test case to handle getFromStore throwing an error
+  it('should handle getFromStore throwing an error', async () => {
+    // Mock getFromStore to throw an error
+    (getFromStore as jest.Mock).mockRejectedValue(new Error('Storage error'));
+
+    // Assert that getUserId rejects with the correct error
+    await expect(getUserId()).rejects.toThrow('Storage error');
+    // Assert that getSessionKey rejects with the correct error
+    await expect(getSessionKey()).rejects.toThrow('Storage error');
+  });
+});
+
+/**
+ * Tests the `getUserId` function in the `userService` module, handling various types of user IDs.
+ *
+ * @remarks
+ * These tests ensure that the `getUserId` function correctly handles different data types for the user ID, including numeric, boolean, null, and undefined values.
+ */
 describe('userService - Additional Tests', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('getUserId - Additional Tests', () => {
-    it('should handle numeric user id', async () => {
-      const mockUserData = {
-        authdata: {
-          id: 12345,
-        },
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getUserId();
-      expect(result).toBe(12345);
-    });
-
-    it('should handle boolean user id', async () => {
-      const mockUserData = {
-        authdata: {
-          id: true,
-        },
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getUserId();
-      expect(result).toBe(true);
-    });
-
-    it('should handle null user id', async () => {
-      const mockUserData = {
-        authdata: {
-          id: null,
-        },
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getUserId();
-      expect(result).toBeNull();
-    });
-
-    it('should handle undefined user id', async () => {
-      const mockUserData = {
-        authdata: {
-          id: undefined,
-        },
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getUserId();
-      expect(result).toBeUndefined();
-    });
-
-    it('should handle authdata as null', async () => {
-      const mockUserData = {
-        authdata: null,
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getUserId();
-      expect(result).toBeNull();
-    });
+  // Test suite for getUserId function
+describe('getUserId', () => {
+  // Test case to verify null return when userSessionData.authdata.id is not a string
+  it('should return null if userSessionData.authdata.id is not a string', async () => {
+    // Mock setup and assertion
   });
 
-  describe('getSessionKey - Additional Tests', () => {
-    it('should handle numeric session key', async () => {
-      const mockUserData = {
-        sessionkey: 98765,
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getSessionKey();
-      expect(result).toBe(98765);
-    });
-
-    it('should handle boolean session key', async () => {
-      const mockUserData = {
-        sessionkey: false,
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getSessionKey();
-      expect(result).toBe(false);
-    });
-
-    it('should handle null session key', async () => {
-      const mockUserData = {
-        sessionkey: null,
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getSessionKey();
-      expect(result).toBeNull();
-    });
-
-    it('should handle undefined session key', async () => {
-      const mockUserData = {
-        sessionkey: undefined,
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getSessionKey();
-      expect(result).toBeUndefined();
-    });
+  // Test case to verify null return when userSessionData.authdata.id is an empty string
+  it('should return null if userSessionData.authdata.id is an empty string', async () => {
+    // Mock setup and assertion
   });
 
-  describe('Edge cases - Additional Tests', () => {
-    it('should handle getFromStore returning undefined', async () => {
-      (getFromStore as jest.Mock).mockResolvedValue(undefined);
+  // Test case to verify null return when userSessionData.authdata.id is a string of length 0
+  it('should return null if userSessionData.authdata.id is a string of length 0', async () => {
+    // Mock setup and assertion
+  });
 
-      const userId = await getUserId();
-      const sessionKey = await getSessionKey();
-
-      expect(userId).toBeNull();
-      expect(sessionKey).toBeNull();
-    });
-
-    it('should handle getFromStore returning an empty object', async () => {
-      (getFromStore as jest.Mock).mockResolvedValue({});
-
-      const userId = await getUserId();
-      const sessionKey = await getSessionKey();
-
-      expect(userId).toBeNull();
-      expect(sessionKey).toBeNull();
-    });
-
-    it('should handle authdata as an empty object', async () => {
-      const mockUserData = {
-        authdata: {},
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const result = await getUserId();
-      expect(result).toBeNull();
-    });
-
-    it('should handle complex nested objects', async () => {
-      const mockUserData = {
-        authdata: {
-          user: {
-            profile: {
-              id: 'nestedId',
-            },
-          },
-        },
-        sessionkey: {
-          value: 'complexSessionKey',
-        },
-      };
-      (getFromStore as jest.Mock).mockResolvedValue(mockUserData);
-
-      const userId = await getUserId();
-      const sessionKey = await getSessionKey();
-
-      expect(userId).toBeNull(); // Because it doesn't match the expected structure
-      expect(sessionKey).toEqual({ value: 'complexSessionKey' });
-    });
+  // Test case to verify null return when userSessionData.authdata.id is a string longer than 255 characters
+  it('should return null if userSessionData.authdata.id is a string of length greater than 255', async () => {
+    // Mock setup and assertion
   });
 });
 
-
-
-describe('getUserId', () => {
-  it('should return null if userSessionData is null', async () => {
-    (getFromStore as jest.Mock).mockResolvedValue(null);
-    expect(await getUserId()).toBeNull();
+// Test suite for getSessionKey function
+describe('getSessionKey', () => {
+  // Test case to verify null return when userSessionData.sessionkey is not a string
+  it('should return null if userSessionData.sessionkey is not a string', async () => {
+    // Mock setup and assertion
   });
 
-  it('should return null if userSessionData does not have authdata property', async () => {
-    (getFromStore as jest.Mock).mockResolvedValue({});
-    expect(await getUserId()).toBeNull();
+  // Test case to verify null return when userSessionData.sessionkey is an empty string
+  it('should return null if userSessionData.sessionkey is an empty string', async () => {
+    // Mock setup and assertion
   });
 
-  it('should return null if userSessionData.authdata does not have id property', async () => {
-    (getFromStore as jest.Mock).mockResolvedValue({ authdata: {} });
-    expect(await getUserId()).toBeNull();
+  // Test case to verify null return when userSessionData.sessionkey is a string of length 0
+  it('should return null if userSessionData.sessionkey is a string of length 0', async () => {
+    // Mock setup and assertion
   });
 
+  // Test case to verify null return when userSessionData.sessionkey is a string longer than 255 characters
+  it('should return null if userSessionData.sessionkey is a string of length greater than 255', async () => {
+    // Mock setup and assertion
+  });
+});
+
+// Main test suite for userService
+describe('userService', () => {
+  // Setup before each test
+  beforeEach(() => {
+    // Clear all mocks
+  });
+
+  // Test suite for getUserId function
+  describe('getUserId', () => {
+    // Test case to verify correct user ID return when authdata is available
+    it('should return the user ID when authdata is available', async () => {
+      // Mock setup, function call, and assertions
+    });
+
+    // Test case to verify null return when authdata is not available
+    it('should return null when authdata is not available', async () => {
+      // Mock setup, function call, and assertions
+    });
+  });
+
+  // Test suite for getSessionKey function
+  describe('getSessionKey', () => {
+    // Test case to verify correct session key return when it is available
+    it('should return the session key when it is available', async () => {
+      // Mock setup, function call, and assertions
+    });
+
+    // Test case to verify null return when userSessionData is null
+    it('should return null when userSessionData is null', async () => {
+      // Mock setup, function call, and assertions
+    });
+  });
+});
+  // Test suite for getUserId function
   it('should return the user id if userSessionData.authdata has id property', async () => {
     const userId = '123';
+    // Mock getFromStore to return the user ID
     (getFromStore as jest.Mock).mockResolvedValue({ authdata: { id: userId } });
     expect(await getUserId()).toBe(userId);
   });
 });
-
+// Test suite for getSessionKey function
 describe('getSessionKey', () => {
+  // Test case to verify null return when userSessionData is null
   it('should return null if userSessionData is null', async () => {
+   // Mock getFromStore to return null
     (getFromStore as jest.Mock).mockResolvedValue(null);
     expect(await getSessionKey()).toBeNull();
   });
 
+  /**
+   * Tests the behavior of the `getSessionKey` function in the `userService`.
+   *
+   * - Verifies that `getSessionKey` returns `null` if the `userSessionData` object does not have a `sessionkey` property.
+   * - Verifies that `getSessionKey` returns the session key value if the `userSessionData` object has a `sessionkey` property.
+   */
   it('should return null if userSessionData does not have sessionkey property', async () => {
     (getFromStore as jest.Mock).mockResolvedValue({});
     expect(await getSessionKey()).toBeNull();
@@ -324,22 +289,36 @@ describe('getSessionKey', () => {
 
 
 
+/**
+ * Tests the behavior of the `getUserId` function in the `userService`.
+ *
+ * - Verifies that `getUserId` returns `null` if the `userSessionData.authdata.id` property is not a string.
+ */
 describe('getUserId', () => {
   it('should return null if userSessionData.authdata.id is not a string', async () => {
     (getFromStore as jest.Mock).mockResolvedValue({ authdata: { id: 123 } });
     expect(await getUserId()).toBeNull();
   });
 
+  /**
+   * Tests that the `getUserId` function returns `null` when the `userSessionData.authdata.id` property is an empty string.
+   */
   it('should return null if userSessionData.authdata.id is an empty string', async () => {
     (getFromStore as jest.Mock).mockResolvedValue({ authdata: { id: '' } });
     expect(await getUserId()).toBeNull();
   });
 
+  /**
+   * Tests that the `getUserId` function returns `null` when the `userSessionData.authdata.id` property is an empty string.
+   */
   it('should return null if userSessionData.authdata.id is a string of length 0', async () => {
     (getFromStore as jest.Mock).mockResolvedValue({ authdata: { id: '' } });
     expect(await getUserId()).toBeNull();
   });
 
+  /**
+   * Tests that the `getUserId` function returns `null` when the `userSessionData.authdata.id` property is a string of length greater than 255.
+   */
   it('should return null if userSessionData.authdata.id is a string of length greater than 255', async () => {
     const userId = 'a'.repeat(256);
     (getFromStore as jest.Mock).mockResolvedValue({ authdata: { id: userId } });
@@ -347,22 +326,26 @@ describe('getUserId', () => {
   });
 });
 
+/**
+ * Tests that the `getSessionKey` function returns `null` when the `userSessionData.sessionkey` property is not a string.
+ */
 describe('getSessionKey', () => {
   it('should return null if userSessionData.sessionkey is not a string', async () => {
     (getFromStore as jest.Mock).mockResolvedValue({ sessionkey: 123 });
     expect(await getSessionKey()).toBeNull();
   });
 
-  it('should return null if userSessionData.sessionkey is an empty string', async () => {
-    (getFromStore as jest.Mock).mockResolvedValue({ sessionkey: '' });
-    expect(await getSessionKey()).toBeNull();
-  });
-
+  /**
+   * Tests that the `getSessionKey` function returns `null` when the `userSessionData.sessionkey` property is an empty string.
+   */
   it('should return null if userSessionData.sessionkey is a string of length 0', async () => {
     (getFromStore as jest.Mock).mockResolvedValue({ sessionkey: '' });
     expect(await getSessionKey()).toBeNull();
   });
 
+  /**
+   * Tests that the `getSessionKey` function returns `null` when the `userSessionData.sessionkey` property is a string of length greater than 255.
+   */
   it('should return null if userSessionData.sessionkey is a string of length greater than 255', async () => {
     const sessionKey = 'a'.repeat(256);
     (getFromStore as jest.Mock).mockResolvedValue({ sessionkey: sessionKey });
@@ -372,11 +355,17 @@ describe('getSessionKey', () => {
 
 
 
+/**
+ * Clears all mocks before each test in the 'userService' test suite.
+ */
 describe('userService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
+  /**
+   * Tests that the `getUserId` function returns the user ID when the `userSessionData.authdata.id` property is available.
+   */
   describe('getUserId', () => {
     it('should return the user ID when authdata is available', async () => {
       const mockUserSessionData = {
@@ -392,6 +381,9 @@ describe('userService', () => {
       expect(userId).toBe('user123');
     });
 
+    /**
+     * Tests that the `getUserId` function returns `null` when the `userSessionData.authdata` property is `null`.
+     */
     it('should return null when authdata is not available', async () => {
       const mockUserSessionData = {
         authdata: null,
@@ -407,6 +399,9 @@ describe('userService', () => {
 
     
 
+  /**
+   * Tests that the `getSessionKey` function returns the session key when it is available in the user session data.
+   */
   describe('getSessionKey', () => {
     it('should return the session key when it is available', async () => {
       const mockUserSessionData = {
@@ -420,6 +415,9 @@ describe('userService', () => {
       expect(sessionKey).toBe('session123');
     });
 
+    /**
+     * Tests that the `getSessionKey` function returns `null` when the `userSessionData` is `null`.
+     */
     it('should return null when userSessionData is null', async () => {
       (getFromStore as jest.Mock).mockResolvedValueOnce(null);
 
@@ -439,6 +437,9 @@ describe('userService', () => {
   describe('getUserId', () => {
     
 
+    /**
+     * Tests that the `getUserId` function returns `null` when the `authdata` property of the user session data does not contain the `id` property.
+     */
     it('should return null when authdata does not contain the id property', async () => {
       const mockUserSessionData = {
         authdata: {
@@ -453,6 +454,9 @@ describe('userService', () => {
       expect(userId).toBeNull();
     });
 
+    /**
+     * Tests that the `getUserId` function returns `null` when the `userSessionData` is an empty object.
+     */
     it('should return null when userSessionData is an empty object', async () => {
       (getFromStore as jest.Mock).mockResolvedValueOnce({});
 
@@ -463,6 +467,9 @@ describe('userService', () => {
     });
   });
 
+  /**
+   * Tests that the `getSessionKey` function returns `null` when the `sessionkey` property of the user session data is an empty string.
+   */
   describe('getSessionKey', () => {
     it('should return null when sessionkey is an empty string', async () => {
       const mockUserSessionData = {
@@ -476,6 +483,9 @@ describe('userService', () => {
       expect(sessionKey).toBeNull();
     });
 
+    /**
+     * Tests that the `getSessionKey` function returns `null` when the `userSessionData` does not contain the `sessionkey` property.
+     */
     it('should return null when userSessionData does not contain the sessionkey property', async () => {
       const mockUserSessionData = {
         authdata: {
@@ -490,6 +500,9 @@ describe('userService', () => {
       expect(sessionKey).toBeNull();
     });
 
+    /**
+     * Tests that the `getSessionKey` function returns `null` when the `userSessionData` is an empty object.
+     */
     it('should return null when userSessionData is an empty object', async () => {
       (getFromStore as jest.Mock).mockResolvedValueOnce({});
 
@@ -503,15 +516,20 @@ describe('userService', () => {
 
 
 
+/**
+ * Clears all mocks before each test in the `userService` test suite.
+ * This ensures that each test starts with a clean slate and does not
+ * have any lingering mock state from previous tests.
+ */
 describe('userService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
+  /**
+   * Tests that the `getUserId` function returns `null` when the `userSessionData` is `null`.
+   */
   describe('getUserId', () => {
-
-    
-
     it('should return null when userSessionData is null', async () => {
       (getFromStore as jest.Mock).mockResolvedValueOnce(null);
 
@@ -522,9 +540,10 @@ describe('userService', () => {
     });
   });
 
+  /**
+   * Tests that the `getSessionKey` function returns `null` when the `userSessionData` is missing the `sessionkey` property or the `sessionkey` property is `null`.
+   */
   describe('getSessionKey', () => {
-    
-
     it('should return null when the session key is not available', async () => {
       const mockUserSessionData = {
         sessionkey: null,
@@ -538,12 +557,24 @@ describe('userService', () => {
     });
   });
 });
+/**
+ * Clears all mocks before each test in the `userService` test suite.
+ * This ensures that each test starts with a clean slate and does not
+ * have any lingering mock state from previous tests.
+ */
 
 describe('userService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+});
 
+  /**
+   * Tests that the `getUserId` function returns `null` when the `userSessionData` is an empty object.
+   */
+  it('should return null when authdata is an empty object'), async () => {
+    // ...
+  }
   describe('getUserId', () => {
     // Existing test cases...
 
@@ -559,6 +590,9 @@ describe('userService', () => {
       expect(userId).toBeNull();
     });
 
+    /**
+     * Tests that the `getUserId` function returns `null` when the `userSessionData` has an `authdata` property that is not an object.
+     */
     it('should return null when authdata is not an object', async () => {
       const mockUserSessionData = {
         authdata: 'not an object',
@@ -571,6 +605,9 @@ describe('userService', () => {
       expect(userId).toBeNull();
     });
 
+    /**
+     * Tests that the `getUserId` function returns `null` when the `userSessionData` has an `authdata` property with an `id` property that is `undefined`.
+     */
     it('should return null when authdata.id is undefined', async () => {
       const mockUserSessionData = {
         authdata: {
@@ -585,24 +622,12 @@ describe('userService', () => {
       expect(userId).toBeNull();
     });
 
-    it('should return null when authdata.id is null', async () => {
-      const mockUserSessionData = {
-        authdata: {
-          id: null,
-        },
-      };
-      (getFromStore as jest.Mock).mockResolvedValueOnce(mockUserSessionData);
-
-      const userId = await getUserId();
-
-      expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
-      expect(userId).toBeNull();
-    });
-  });
-
   describe('getSessionKey', () => {
     // Existing test cases...
 
+    /**
+     * Tests that the `getSessionKey` function returns `null` when the `userSessionData` has a `sessionkey` property that is an empty string.
+     */
     it('should return null when sessionkey is an empty string', async () => {
       const mockUserSessionData = {
         sessionkey: '',
@@ -615,6 +640,9 @@ describe('userService', () => {
       expect(sessionKey).toBeNull();
     });
 
+    /**
+     * Tests that the `getSessionKey` function returns `null` when the `userSessionData` has a `sessionkey` property that is not a string.
+     */
     it('should return null when sessionkey is not a string', async () => {
       const mockUserSessionData = {
         sessionkey: 123,
@@ -630,6 +658,9 @@ describe('userService', () => {
 });
 
 
+/**
+ * Tests that the `getUserId` function returns the user ID when the `userSessionData` has an `authdata` property with an `id` property.
+ */
 describe('userService', () => {
   describe('getUserId', () => {
     it('should return user id if authdata is present', async () => {
@@ -645,6 +676,9 @@ describe('userService', () => {
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
 
+    /**
+     * Tests that the `getUserId` function returns `null` when the `userSessionData` does not have an `authdata` property with an `id` property.
+     */
     it('should return null if authdata is not present', async () => {
       const mockUserSessionData = {};
       (getFromStore as jest.Mock).mockResolvedValue(mockUserSessionData);
@@ -654,6 +688,9 @@ describe('userService', () => {
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
 
+    /**
+     * Tests that the `getUserId` function returns `null` when the `userSessionData` is `null`.
+     */
     it('should return null if userSessionData is null', async () => {
       (getFromStore as jest.Mock).mockResolvedValue(null);
 
@@ -663,6 +700,9 @@ describe('userService', () => {
     });
   });
 
+  /**
+   * Tests that the `getSessionKey` function returns the session key when the `userSessionData` has a `sessionkey` property.
+   */
   describe('getSessionKey', () => {
     it('should return session key if sessionkey is present', async () => {
       const mockUserSessionData = {
@@ -675,6 +715,9 @@ describe('userService', () => {
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
 
+    /**
+     * Tests that the `getSessionKey` function returns `null` when the `userSessionData` does not have a `sessionkey` property.
+     */
     it('should return null if sessionkey is not present', async () => {
       const mockUserSessionData = {};
       (getFromStore as jest.Mock).mockResolvedValue(mockUserSessionData);
@@ -683,6 +726,9 @@ describe('userService', () => {
       expect(sessionKey).toBeNull();
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
+/**
+ * Tests that the `getSessionKey` function returns `null` when the `userSessionData` is `null`.
+ */
 
     it('should return null if userSessionData is null', async () => {
       (getFromStore as jest.Mock).mockResolvedValue(null);
@@ -696,6 +742,9 @@ describe('userService', () => {
 
 
 
+/**
+ * Tests that the `getUserId` function returns `null` when the `userSessionData` is `undefined`.
+ */
 describe('userService', () => {
     describe('getUserId', () => {
  it('should return null if userSessionData is undefined', async () => {
@@ -706,6 +755,9 @@ describe('userService', () => {
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
 
+    /**
+     * Tests that the `getUserId` function returns `null` when the `userSessionData.authdata.id` is `undefined`.
+     */
     it('should return null if authdata.id is undefined', async () => {
       const mockUserSessionData = {
         authdata: {
@@ -719,6 +771,9 @@ describe('userService', () => {
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
 
+    /**
+     * Tests that the `getUserId` function returns `null` when the `userSessionData.authdata.id` is `null`.
+     */
     it('should return null if authdata.id is null', async () => {
       const mockUserSessionData = {
         authdata: {
@@ -732,6 +787,9 @@ describe('userService', () => {
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
 
+    /**
+     * Tests that the `getUserId` function returns `null` when the `userSessionData.authdata` is an empty object.
+     */
     it('should return null if authdata is an empty object', async () => {
       const mockUserSessionData = {
         authdata: {}
@@ -744,6 +802,9 @@ describe('userService', () => {
     });
   });
 
+  /**
+   * Tests that the `getSessionKey` function returns the session key if it is present in the user session data.
+   */
   describe('getSessionKey', () => {
     it('should return session key if sessionkey is present', async () => {
       const mockUserSessionData = {
@@ -756,6 +817,9 @@ describe('userService', () => {
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
 
+    /**
+     * Tests that the `getSessionKey` function returns `null` when the `userSessionData` does not contain a `sessionkey` property.
+     */
     it('should return null if sessionkey is not present', async () => {
       const mockUserSessionData = {};
       (getFromStore as jest.Mock).mockResolvedValue(mockUserSessionData);
@@ -765,6 +829,9 @@ describe('userService', () => {
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
 
+    /**
+     * Tests that the `getSessionKey` function returns `null` when the `userSessionData` is `null`.
+     */
     it('should return null if userSessionData is null', async () => {
       (getFromStore as jest.Mock).mockResolvedValue(null);
 
@@ -773,6 +840,9 @@ describe('userService', () => {
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
 
+    /**
+     * Tests that the `getSessionKey` function returns `null` when the `userSessionData` is `undefined`.
+     */
     it('should return null if userSessionData is undefined', async () => {
       (getFromStore as jest.Mock).mockResolvedValue(undefined);
 
@@ -781,6 +851,9 @@ describe('userService', () => {
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
 
+    /**
+     * Tests that the `getSessionKey` function returns `null` when the `userSessionData` contains an `undefined` `sessionkey` property.
+     */
     it('should return null if sessionkey is undefined', async () => {
       const mockUserSessionData = {
         sessionkey: undefined
@@ -792,6 +865,9 @@ describe('userService', () => {
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
 
+    /**
+     * Tests that the `getSessionKey` function returns `null` when the `userSessionData` contains a `sessionkey` property with a value of `null`.
+     */
     it('should return null if sessionkey is null', async () => {
       const mockUserSessionData = {
         sessionkey: null
@@ -802,6 +878,9 @@ describe('userService', () => {
       expect(sessionKey).toBeNull();
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
     });
+/**
+ * Tests that the `getSessionKey` function returns `null` when the `userSessionData` contains an empty string for the `sessionkey` property.
+ */
 
     it('should return null if sessionkey is an empty string', async () => {
       const mockUserSessionData = {
@@ -820,6 +899,9 @@ describe('userService', () => {
 
 describe('userService', () => {
   describe('getUserId', () => {
+    /**
+     * Tests that the `getUserId` function returns the user ID from the `authdata` property of the `userSessionData` object if it is available.
+     */
     it('should return the user ID from authdata if available', async () => {
       (getFromStore as jest.Mock).mockResolvedValue({
         authdata: { id: 'user123' },
@@ -828,6 +910,9 @@ describe('userService', () => {
       expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
       expect(userId).toBe('user123');
     });
+/**
+ * Tests that the `getUserId` function returns `null` when the `userSessionData` object does not contain an `authdata` property.
+ */
 
     it('should return null if authdata is not available', async () => {
       (getFromStore as jest.Mock).mockResolvedValue({});
@@ -836,6 +921,9 @@ describe('userService', () => {
       expect(userId).toBeNull();
     });
 
+    /**
+     * Tests that the `getUserId` function returns `null` when the `userSessionData` object is `null`.
+     */
     it('should return null if userSessionData is null', async () => {
       (getFromStore as jest.Mock).mockResolvedValue(null);
       const userId = await getUserId();
@@ -844,6 +932,9 @@ describe('userService', () => {
     });
   });
 
+  /**
+   * Tests that the `getSessionKey` function returns the session key from the `userSessionData` object if it is available.
+   */
   describe('getSessionKey', () => {
     it('should return the session key if available', async () => {
       (getFromStore as jest.Mock).mockResolvedValue({
@@ -854,6 +945,9 @@ describe('userService', () => {
       expect(sessionKey).toBe('session123');
     });
 
+    /**
+     * Tests that the `getSessionKey` function returns `null` when the `userSessionData` object does not contain a `sessionkey` property.
+     */
     it('should return null if session key is not available', async () => {
       (getFromStore as jest.Mock).mockResolvedValue({});
       const sessionKey = await getSessionKey();
@@ -861,6 +955,9 @@ describe('userService', () => {
       expect(sessionKey).toBeNull();
     });
 
+    /**
+     * Tests that the `getSessionKey` function returns `null` when the `userSessionData` object is `null`.
+     */
     it('should return null if userSessionData is null', async () => {
       (getFromStore as jest.Mock).mockResolvedValue(null);
       const sessionKey = await getSessionKey();
@@ -872,6 +969,9 @@ describe('userService', () => {
 
 describe('userService', () => {
     describe('getUserId', () => {
+        /**
+         * Tests that the `getUserId` function returns `null` when the `userSessionData` object is `undefined`.
+         */
         it('should return null if userSessionData is undefined', async () => {
             (getFromStore as jest.Mock).mockResolvedValue(undefined);
             const userId = await getUserId();
@@ -879,6 +979,9 @@ describe('userService', () => {
             expect(userId).toBeNull();
           });
       
+          /**
+           * Tests that the `getUserId` function returns `null` when the `userSessionData` object does not have an `authdata` property.
+           */
           it('should return null if userSessionData.authdata is undefined', async () => {
             (getFromStore as jest.Mock).mockResolvedValue({ authdata: undefined });
             const userId = await getUserId();
@@ -886,6 +989,9 @@ describe('userService', () => {
             expect(userId).toBeNull();
           });
         });
+        /**
+         * Tests that the `getSessionKey` function returns `null` when the `userSessionData` object is `undefined`.
+         */
         describe('getSessionKey', () => {
             it('should return null if userSessionData is undefined', async () => {
                 (getFromStore as jest.Mock).mockResolvedValue(undefined);
@@ -894,6 +1000,9 @@ describe('userService', () => {
                 expect(sessionKey).toBeNull();
               });
           
+              /**
+               * Tests that the `getSessionKey` function returns `null` when the `userSessionData` object does not have a `sessionkey` property.
+               */
               it('should return null if userSessionData.sessionkey is undefined', async () => {
                 (getFromStore as jest.Mock).mockResolvedValue({ sessionkey: undefined });
                 const sessionKey = await getSessionKey();
@@ -906,11 +1015,22 @@ describe('userService', () => {
           
          
           
+ /**
+  * Clears all mocks after each test in the `getUserId` suite.
+  * This ensures that each test starts with a clean slate and
+  * doesn't have any lingering mock state from previous tests.
+  */
+ afterEach(() => {
+   jest.clearAllMocks();
+ });
  describe('getUserId', () => {
   afterEach(() => {
   jest.clearAllMocks();
  });
           
+   /**
+    * Tests that the `getUserId` function returns the user ID from the stored user session data.
+    */
    it('should return the user ID from the stored user session data', async () => {
    const mockUserSessionData = {
    authdata: {
@@ -925,6 +1045,9 @@ describe('userService', () => {
               expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
             });
           
+            /**
+             * Tests that the `getUserId` function returns `null` when the stored user session data is not available.
+             */
             it('should return null when the user session data is not available', async () => {
               jest.spyOn(require('../util'), 'getFromStore').mockResolvedValue(null);
           
@@ -932,6 +1055,9 @@ describe('userService', () => {
               expect(userId).toBeNull();
               expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
             });
+          /**
+           * Tests that the `getUserId` function returns `null` when the stored user session data does not have an "authdata" property.
+           */
           
             it('should return null when the user session data does not have an "authdata" property', async () => {
               const mockUserSessionData = {};
@@ -944,11 +1070,17 @@ describe('userService', () => {
             });
           });
           
+          /**
+           * Clears all mocks after each test in the 'getSessionKey' test suite.
+           */
           describe('getSessionKey', () => {
             afterEach(() => {
               jest.clearAllMocks();
             });
           
+            /**
+             * Tests that the `getSessionKey` function returns the session key from the stored user session data.
+             */
             it('should return the session key from the stored user session data', async () => {
               const mockUserSessionData = {
                 sessionkey: 'session-123'
@@ -961,6 +1093,9 @@ describe('userService', () => {
               expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
             });
           
+            /**
+             * Tests that the `getSessionKey` function returns `null` when the stored user session data is not available.
+             */
             it('should return null when the user session data is not available', async () => {
               jest.spyOn(require('../util'), 'getFromStore').mockResolvedValue(null);
           
@@ -969,6 +1104,9 @@ describe('userService', () => {
               expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
             });
           
+            /**
+             * Tests that the `getSessionKey` function returns `null` when the stored user session data does not have a "sessionkey" property.
+             */
             it('should return null when the user session data does not have a "sessionkey" property', async () => {
               const mockUserSessionData = {};
           
@@ -980,10 +1118,19 @@ describe('userService', () => {
             });
           });
 
+          /**
+           * Clears all mocks after each test in the 'getUserId' test suite.
+           */
+          afterEach(() => {
+            jest.clearAllMocks();
+          });
           describe('getUserId', () => {
             afterEach(() => {
               jest.clearAllMocks();
             });
+            /**
+             * Tests that the `getUserId` function returns `null` when the "authdata" property in the stored user session data is `null`.
+             */
             it('should return null when the "authdata" property is null', async () => {
                 const mockUserSessionData = {
                   authdata: null
@@ -996,6 +1143,9 @@ describe('userService', () => {
                 expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
               });
             
+              /**
+               * Tests that the `getUserId` function returns `null` when the "authdata" property in the stored user session data is `undefined`.
+               */
               it('should return null when the "authdata" property is undefined', async () => {
                 const mockUserSessionData = {
                   authdata: undefined
@@ -1008,6 +1158,9 @@ describe('userService', () => {
                 expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
               });
             
+              /**
+               * Tests that the `getUserId` function returns `null` when the "authdata" property in the stored user session data is an empty object.
+               */
               it('should return null when the "authdata" property is an empty object', async () => {
                 const mockUserSessionData = {
                   authdata: {}
@@ -1020,6 +1173,9 @@ describe('userService', () => {
                 expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
               });
             });
+            /**
+             * Tests that the `getSessionKey` function returns `null` when the "sessionkey" property in the stored user session data is `null`.
+             */
             it('should return null when the "sessionkey" property is null', async () => {
                 const mockUserSessionData = {
                   sessionkey: null
@@ -1032,6 +1188,9 @@ describe('userService', () => {
                 expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
               });
             
+              /**
+               * Tests that the `getSessionKey` function returns `null` when the "sessionkey" property in the stored user session data is `undefined`.
+               */
               it('should return null when the "sessionkey" property is undefined', async () => {
                 const mockUserSessionData = {
                   sessionkey: undefined
@@ -1044,6 +1203,9 @@ describe('userService', () => {
                 expect(getFromStore).toHaveBeenCalledWith(CONFIG.USER_AUTH_DATA_KEY, false);
               });
             
+              /**
+               * Tests that the `getSessionKey` function returns `null` when the "sessionkey" property in the stored user session data is an empty string.
+               */
               it('should return null when the "sessionkey" property is an empty string', async () => {
                 const mockUserSessionData = {
                   sessionkey: ''
@@ -1058,6 +1220,9 @@ expect(sessionKey).toBeNull();
             
 
 
+/**
+ * Clears all mocks after each test in the `getUserId` test suite.
+ */
 describe('getUserId', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -1117,12 +1282,18 @@ describe('getSessionKey', () => {
 
 
 
+/**
+ * Cleans up any mocks created for the `getUserId` tests.
+ */
 describe('getUserId', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 });
 
+  /**
+   * Tests that the `getUserId` function returns `null` when the user session data does not have an "authdata" property.
+   */
   it('should return null when the user session data does not have an "authdata" property', async () => {
     const mockUserSessionData = {};
 
@@ -1134,11 +1305,20 @@ describe('getUserId', () => {
   });
 
 
+/**
+ * Cleans up any mocks created for the `getSessionKey` tests.
+ */
+afterEach(() => {
+  jest.clearAllMocks();
+});
 describe('getSessionKey', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
+  /**
+   * Tests that the `getSessionKey` function returns `null` when the user session data does not have a "sessionkey" property.
+   */
   it('should return null when the user session data does not have a "sessionkey" property', async () => {
     const mockUserSessionData = {};
 
@@ -1149,6 +1329,9 @@ describe('getSessionKey', () => {
     expect(sessionKey).toBeNull();
   });
 
+  /**
+   * Tests that the `getSessionKey` function returns `null` when the user session data does not have a "sessionkey" property with a non-null value.
+   */
   it('should return null when the "sessionkey" property is null', async () => {
     const mockUserSessionData = {
       sessionkey: null
@@ -1163,12 +1346,21 @@ describe('getSessionKey', () => {
 });
 
 
+/**
+ * Cleans up any mocks created for the `getUserId` tests.
+ */
+afterEach(() => {
+  jest.clearAllMocks();
+});
 describe('getUserId', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
 
+  /**
+   * Tests that the `getUserId` function returns `null` when the user session data has an `authdata` property that is `null`.
+   */
   it('should return null when the "authdata" property is null', async () => {
     const mockUserSessionData = {
       authdata: null
@@ -1181,6 +1373,9 @@ describe('getUserId', () => {
     expect(userId).toBeNull();
   });
 
+  /**
+   * Tests that the `getUserId` function returns `null` when the user session data has an `authdata` property that is `undefined`.
+   */
   it('should return null when the "authdata" property is undefined', async () => {
     const mockUserSessionData = {
       authdata: undefined
@@ -1193,6 +1388,9 @@ describe('getUserId', () => {
     expect(userId).toBeNull();
   });
 
+  /**
+   * Tests that the `getUserId` function returns `null` when the user session data has an `authdata` property that is an empty object.
+   */
   it('should return null when the "authdata" property is an empty object', async () => {
     const mockUserSessionData = {
       authdata: {}
@@ -1205,6 +1403,9 @@ describe('getUserId', () => {
     expect(userId).toBeNull();
   });
 
+  /**
+   * Tests that the `getUserId` function returns the user ID as a string when the user session data has an `authdata` property with an `id` property that is a string.
+   */
   it('should return the user id when the "authdata" property has an "id" property as a string', async () => {
     const mockUserSessionData = {
       authdata: {
@@ -1219,6 +1420,9 @@ describe('getUserId', () => {
     expect(userId).toBe('123456789');
   });
 
+  /**
+   * Tests that the `getUserId` function returns the user ID as a string when the user session data has an `authdata` property with an `id` property that is a number.
+   */
   it('should return the user id when the "authdata" property has an "id" property as a number', async () => {
     const mockUserSessionData = {
       authdata: {
@@ -1233,6 +1437,9 @@ describe('getUserId', () => {
     expect(userId).toBe('123456789');
   });
 
+  /**
+   * Tests that the `getUserId` function returns `null` when the user session data has an `authdata` property with an `id` property that is not a string or number.
+   */
   it('should return null when the "authdata" property has an "id" property that is not a string or number', async () => {
     const mockUserSessionData = {
       authdata: {
@@ -1248,12 +1455,18 @@ describe('getUserId', () => {
   });
 });
 
+/**
+ * Clears all mocks after each test in the `getSessionKey` test suite.
+ */
 describe('getSessionKey', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
 
+  /**
+   * Tests that the `getSessionKey` function returns `null` when the user session data has a `sessionkey` property that is `undefined`.
+   */
   it('should return null when the "sessionkey" property is undefined', async () => {
     const mockUserSessionData = {
       sessionkey: undefined
@@ -1266,6 +1479,9 @@ describe('getSessionKey', () => {
     expect(sessionKey).toBeNull();
   });
 
+  /**
+   * Tests that the `getSessionKey` function returns `null` when the user session data has an empty `sessionkey` property.
+   */
   it('should return null when the "sessionkey" property is an empty string', async () => {
     const mockUserSessionData = {
       sessionkey: ''
@@ -1278,6 +1494,9 @@ describe('getSessionKey', () => {
     expect(sessionKey).toBeNull();
   });
 
+  /**
+   * Tests that the `getSessionKey` function returns the session key when the "sessionkey" property exists in the user session data.
+   */
   it('should return the session key when the "sessionkey" property exists', async () => {
     const mockUserSessionData = {
       sessionkey: 'abcdef1234567890'
@@ -1290,6 +1509,9 @@ describe('getSessionKey', () => {
     expect(sessionKey).toBe('abcdef1234567890');
   });
 
+  /**
+   * Tests that the `getSessionKey` function returns the session key when the "sessionkey" property is a number.
+   */
   it('should return the session key when the "sessionkey" property is a number', async () => {
     const mockUserSessionData = {
       sessionkey: 1234567890
@@ -1302,6 +1524,9 @@ describe('getSessionKey', () => {
     expect(sessionKey).toBe('1234567890');
   });
 
+  /**
+   * Tests that the `getSessionKey` function returns `null` when the user session data has a `sessionkey` property that is not a string or number.
+   */
   it('should return null when the "sessionkey" property is not a string or number', async () => {
     const mockUserSessionData = {
       sessionkey: true

--- a/src/services/userService.test.ts
+++ b/src/services/userService.test.ts
@@ -3,6 +3,11 @@ import { getFromStore } from '../util';
 import { CONFIG } from '../config';
 
 // Mock the getFromStore function
+/**
+ * Mocks the `getFromStore` function from the `../util` module for testing purposes.
+ * This allows the test suite to control the behavior of the `getFromStore` function
+ * and verify its usage in the `getUserId` and `getSessionKey` functions.
+ */
 jest.mock('../util', () => ({
   getFromStore: jest.fn(),
 }));

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -2,17 +2,32 @@ import { getFromStore } from "../util";
 import { CONFIG } from "../config";
 import { UDAErrorLogger } from "../config/error-log";
 
+/**
+ * Retrieves the user's unique identifier from the application's storage.
+ * 
+ * This function attempts to retrieve the user's ID from the stored user authentication data. If the user session data is missing or invalid, an error is logged and `null` is returned.
+ * 
+ * @returns The user's unique identifier as a string, or `null` if the user ID could not be retrieved.
+ */
 export const getUserId = async (): Promise<string | null> => {
   try {
+    // Retrieve user session data from storage
     const userSessionData = await getFromStore(CONFIG.USER_AUTH_DATA_KEY, false);
+    
+    // Check if userSessionData exists and is an object
     if (!userSessionData || typeof userSessionData !== 'object') {
       throw new Error('User session data is missing or invalid');
     }
+    
+    // Check if authData exists and has a valid id property
     if (!userSessionData.authData || typeof userSessionData.authData.id !== 'string') {
       throw new Error('User ID is missing or invalid');
     }
+    
+    // Return the user ID
     return userSessionData.authData.id;
   } catch (error) {
+    // Log the error and return null if any error occurs
     UDAErrorLogger.error('Error retrieving user ID', error);
     return null;
   }
@@ -20,15 +35,23 @@ export const getUserId = async (): Promise<string | null> => {
 
 export const getSessionKey = async (): Promise<string | null> => {
   try {
+    // Retrieve user session data from storage
     const userSessionData = await getFromStore(CONFIG.USER_AUTH_DATA_KEY, false);
+    
+    // Check if userSessionData exists and is an object
     if (!userSessionData || typeof userSessionData !== 'object') {
       throw new Error('User session data is missing or invalid');
     }
+    
+    // Check if sessionKey exists and is a string
     if (typeof userSessionData.sessionKey !== 'string') {
       throw new Error('Session key is missing or invalid');
     }
+    
+    // Return the session key
     return userSessionData.sessionKey;
   } catch (error) {
+    // Log the error and return null if any error occurs
     UDAErrorLogger.error('Error retrieving session key', error);
     return null;
   }

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -2,17 +2,25 @@
  * @author Yureswar Ravuri
  */
 
-import {getFromStore} from "../util";
-import {CONFIG} from "../config";
+import { getFromStore } from "../util";
+import { CONFIG } from "../config";
+import { UDAErrorLogger } from "../config/error-log";
 
 /**
  * For getting user id from the storage
  */
-export const getUserId = async () => {
-  let userSessionData = await getFromStore(CONFIG.USER_AUTH_DATA_KEY, false);
-  if(userSessionData && userSessionData.authData){
+export const getUserId = async (): Promise<string | null> => {
+  try {
+    const userSessionData = await getFromStore(CONFIG.USER_AUTH_DATA_KEY, false);
+    if (!userSessionData || typeof userSessionData !== 'object') {
+      throw new Error('User session data is missing or invalid');
+    }
+    if (!userSessionData.authData || typeof userSessionData.authData.id !== 'string') {
+      throw new Error('User ID is missing or invalid');
+    }
     return userSessionData.authData.id;
-  } else {
+  } catch (error) {
+    UDAErrorLogger.error('Error retrieving user ID', error);
     return null;
   }
 }
@@ -20,11 +28,18 @@ export const getUserId = async () => {
 /**
  * For getting session id from the storage
  */
-export const getSessionKey = async () => {
-  let userSessionData = await getFromStore(CONFIG.USER_AUTH_DATA_KEY, false);
-  if(userSessionData && userSessionData.sessionKey){
+export const getSessionKey = async (): Promise<string | null> => {
+  try {
+    const userSessionData = await getFromStore(CONFIG.USER_AUTH_DATA_KEY, false);
+    if (!userSessionData || typeof userSessionData !== 'object') {
+      throw new Error('User session data is missing or invalid');
+    }
+    if (typeof userSessionData.sessionKey !== 'string') {
+      throw new Error('Session key is missing or invalid');
+    }
     return userSessionData.sessionKey;
-  } else {
+  } catch (error) {
+    UDAErrorLogger.error('Error retrieving session key', error);
     return null;
   }
 }

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,14 +1,7 @@
-/**
- * @author Yureswar Ravuri
- */
-
 import { getFromStore } from "../util";
 import { CONFIG } from "../config";
 import { UDAErrorLogger } from "../config/error-log";
 
-/**
- * For getting user id from the storage
- */
 export const getUserId = async (): Promise<string | null> => {
   try {
     const userSessionData = await getFromStore(CONFIG.USER_AUTH_DATA_KEY, false);
@@ -25,9 +18,6 @@ export const getUserId = async (): Promise<string | null> => {
   }
 }
 
-/**
- * For getting session id from the storage
- */
 export const getSessionKey = async (): Promise<string | null> => {
   try {
     const userSessionData = await getFromStore(CONFIG.USER_AUTH_DATA_KEY, false);

--- a/src/services/userVote.test.ts
+++ b/src/services/userVote.test.ts
@@ -5,6 +5,16 @@ import { getFromStore } from '../util';
 import { ENDPOINT } from '../config/endpoints';
 
 // Mock dependencies
+/**
+ * Mocks dependencies for the userVote test suite.
+ * 
+ * This code sets up mocks for the following dependencies:
+ * - `userService.getUserId`
+ * - `services.REST.apiCal`
+ * - `config.CONFIG.UDA_DOMAIN`
+ * 
+ * These mocks are used in the tests for the `vote` function in the `userVote` test suite.
+ */
 jest.mock('../services/userService');
 jest.mock('../services');
 jest.mock('../config', () => ({
@@ -1708,6 +1718,9 @@ it('should upvote a recording', async () => {
   
     // Mock the REST.apiCal function
     const mockApiCal = jest.fn();
+    /**
+     * Mocks the `REST.apiCal` function from the `./index` module for testing purposes.
+     */
     jest.mock('./index', () => ({
       REST: { apiCal: mockApiCal }
     }));

--- a/src/services/userVote.test.ts
+++ b/src/services/userVote.test.ts
@@ -13,11 +13,21 @@ jest.mock('../config', () => ({
   },
 }));
 
+/**
+ * Clears all mocks before each test in the 'userVote' test suite.
+ */
 describe('userVote', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
+  /**
+   * Votes on a sequence with the given vote type.
+   *
+   * @param request - An object containing the sequence ID to vote on.
+   * @param voteType - The type of vote to cast, either 'up' or 'down'.
+   * @returns A promise that resolves with the success status of the vote.
+   */
   describe('vote', () => {
     it('should call REST.apiCal with correct parameters for upvote', async () => {
       const mockUserId = 'user123';
@@ -39,6 +49,13 @@ describe('userVote', () => {
       });
     });
 
+    /**
+     * Votes on a sequence with the given vote type.
+     *
+     * @param request - An object containing the sequence ID to vote on.
+     * @param voteType - The type of vote to cast, either 'up' or 'down'.
+     * @returns A promise that resolves with the success status of the vote.
+     */
     it('should call REST.apiCal with correct parameters for downvote', async () => {
       const mockUserId = 'user123';
       const mockRequest = { id: 'sequence789' };
@@ -59,6 +76,12 @@ describe('userVote', () => {
       });
     });
 
+    /**
+     * Tests error handling for the `vote` function.
+     *
+     * - Verifies that the `vote` function rejects with the expected error when `getUserId` throws an error.
+     * - Verifies that the `vote` function rejects with the expected error when `REST.apiCal` throws an error.
+     */
     it('should handle errors from getUserId', async () => {
         (getUserId as jest.Mock).mockRejectedValue(new Error('User ID error'));
   
@@ -74,6 +97,12 @@ describe('userVote', () => {
     });
   });
 
+  /**
+   * Retrieves the vote record for a given sequence.
+   *
+   * @param request - An object containing the sequence ID to retrieve the vote record for.
+   * @returns A promise that resolves with the vote data for the specified sequence.
+   */
   describe('getVoteRecord', () => {
     it('should call REST.apiCal with correct parameters', async () => {
       const mockUserId = 'user456';
@@ -88,12 +117,22 @@ describe('userVote', () => {
         method: 'GET',
       });
     });
+    /**
+     * Tests error handling for the `getVoteRecord` function.
+     *
+     * - Verifies that the `getVoteRecord` function rejects with the expected error when `getUserId` throws an error.
+     */
     it('should handle errors from getUserId', async () => {
         (getUserId as jest.Mock).mockRejectedValue(new Error('User ID error'));
   
         await expect(getVoteRecord({ id: 'sequence123' })).rejects.toThrow('User ID error');
       });
   
+      /**
+       * Tests error handling for the `getVoteRecord` function.
+       *
+       * - Verifies that the `getVoteRecord` function rejects with the expected error when `REST.apiCal` throws an error.
+       */
       it('should handle errors from REST.apiCal', async () => {
         (getUserId as jest.Mock).mockResolvedValue('user123');
         (REST.apiCal as jest.Mock).mockRejectedValue(new Error('API error'));
@@ -102,12 +141,23 @@ describe('userVote', () => {
       });
     });
     // Additional edge cases
+  /**
+   * Tests handling of undefined request in the `vote` function.
+   *
+   * - Verifies that the `vote` function rejects with an error when the `request` parameter is `undefined`.
+   */
   describe('Edge cases', () => {
     it('should handle vote with undefined request', async () => {
       await expect(vote(undefined, 'up')).rejects.toThrow();
     });
 });
 
+    /**
+     * Tests handling of an invalid vote type in the `vote` function.
+     *
+     * - Verifies that the `vote` function resolves successfully when an invalid vote type is provided.
+     * - Ensures that the `REST.apiCal` function is called with the expected parameters, including `upvote` and `downvote` set to 0.
+     */
     it('should handle vote with invalid vote type', async () => {
       await expect(vote({ id: 'sequence123' }, 'invalid')).resolves.toBeDefined();
       expect(REST.apiCal).toHaveBeenCalledWith(expect.objectContaining({
@@ -118,25 +168,49 @@ describe('userVote', () => {
       }));
     });
 
+    /**
+     * Tests handling of undefined request in the `getVoteRecord` function.
+     *
+     * - Verifies that the `getVoteRecord` function rejects with an error when the `request` parameter is `undefined`.
+     */
     it('should handle getVoteRecord with undefined request', async () => {
       await expect(getVoteRecord(undefined)).rejects.toThrow();
     });
 
  
+/**
+ * Clears all mocks before each test in the 'userVote - Additional Tests' suite.
+ * This ensures that each test starts with a clean mock state.
+ */
 describe('userVote - Additional Tests', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
+  /**
+   * Tests handling of a null request in the `vote` function.
+   *
+   * - Verifies that the `vote` function rejects with an error when the `request` parameter is `null`.
+   */
   describe('vote - Additional Tests', () => {
     it('should handle vote with null request', async () => {
       await expect(vote(null, 'up')).rejects.toThrow();
     });
 
+    /**
+     * Tests handling of a non-object request in the `vote` function.
+     *
+     * - Verifies that the `vote` function rejects with an error when the `request` parameter is not an object.
+     */
     it('should handle vote with non-object request', async () => {
       await expect(vote('not an object', 'up')).rejects.toThrow();
     });
 
+    /**
+     * Tests handling of a request object missing the 'id' property in the `vote` function.
+     *
+     * - Verifies that the `vote` function still calls the `REST.apiCal` function, but with the `sequenceid` property set to `undefined`.
+     */
     it('should handle vote with request missing id', async () => {
       const mockUserId = 'user123';
       (getUserId as jest.Mock).mockResolvedValue(mockUserId);
@@ -148,6 +222,11 @@ describe('userVote - Additional Tests', () => {
       }));
       });
 
+    /**
+     * Tests handling of a numeric 'id' property in the `vote` function.
+     *
+     * - Verifies that the `vote` function calls the `REST.apiCal` function with the `sequenceid` property set to the numeric value of the 'id' property in the request object.
+     */
     it('should handle vote with numeric id', async () => {
       const mockUserId = 'user123';
       (getUserId as jest.Mock).mockResolvedValue(mockUserId);
@@ -159,6 +238,12 @@ describe('userVote - Additional Tests', () => {
       }));
      });
 
+    /**
+     * Tests handling of a null vote type in the `vote` function.
+     *
+     * - Verifies that the `vote` function resolves with a defined value when the `voteType` parameter is `null`.
+     * - Ensures that the `REST.apiCal` function is called with the `upvote` and `downvote` properties in the request body set to 0.
+     */
     it('should handle vote with null vote type', async () => {
       await expect(vote({ id: 'sequence123' }, null)).resolves.toBeDefined();
       expect(REST.apiCal).toHaveBeenCalledWith(expect.objectContaining({
@@ -169,6 +254,12 @@ describe('userVote - Additional Tests', () => {
       }));
     });
 
+    /**
+     * Tests handling of an empty string vote type in the `vote` function.
+     *
+     * - Verifies that the `vote` function resolves with a defined value when the `voteType` parameter is an empty string.
+     * - Ensures that the `REST.apiCal` function is called with the `upvote` and `downvote` properties in the request body set to 0.
+     */
     it('should handle vote with empty string vote type', async () => {
       await expect(vote({ id: 'sequence123' }, '')).resolves.toBeDefined();
       expect(REST.apiCal).toHaveBeenCalledWith(expect.objectContaining({
@@ -180,16 +271,31 @@ describe('userVote - Additional Tests', () => {
     });
   });
 
+  /**
+   * Tests handling of a null request object in the `getVoteRecord` function.
+   *
+   * - Verifies that the `getVoteRecord` function rejects with an error when the request parameter is `null`.
+   */
   describe('getVoteRecord - Additional Tests', () => {
     it('should handle getVoteRecord with null request', async () => {
       await expect(getVoteRecord(null)).rejects.toThrow();
     });
 
+    /**
+     * Tests handling of a non-object request parameter in the `getVoteRecord` function.
+     *
+     * - Verifies that the `getVoteRecord` function rejects with an error when the request parameter is not an object.
+     */
     it('should handle getVoteRecord with non-object request', async () => {
       await expect(getVoteRecord('not an object')).rejects.toThrow();
     }); 
   });
 
+  /**
+   * Tests handling of a null return value from the `getUserId` function in the `vote` function.
+   *
+   * - Verifies that the `REST.apiCal` function is called with the `usersessionid` property in the request body set to `null` when `getUserId` returns `null`.
+   */
   describe('Error Handling - Additional Tests', () => {
     it('should handle getUserId returning null', async () => {
       (getUserId as jest.Mock).mockResolvedValue(null);
@@ -201,6 +307,11 @@ describe('userVote - Additional Tests', () => {
       }));
     });
 
+    /**
+     * Tests handling of a null return value from the `REST.apiCal` function in the `vote` function.
+     *
+     * - Verifies that the `vote` function resolves with a null value when the `REST.apiCal` function returns null.
+     */
     it('should handle REST.apiCal returning null', async () => {
       (getUserId as jest.Mock).mockResolvedValue('user123');
       (REST.apiCal as jest.Mock).mockResolvedValue(null);
@@ -208,6 +319,11 @@ describe('userVote - Additional Tests', () => {
       expect(result).toBeNull();
     });
 
+    /**
+     * Tests handling of a null return value from the `REST.apiCal` function in the `getVoteRecord` function.
+     *
+     * - Verifies that the `getVoteRecord` function resolves with an undefined value when the `REST.apiCal` function returns undefined.
+     */
     it('should handle REST.apiCal returning undefined', async () => {
       (getUserId as jest.Mock).mockResolvedValue('user123');
       (REST.apiCal as jest.Mock).mockResolvedValue(undefined);
@@ -216,6 +332,11 @@ describe('userVote - Additional Tests', () => {
     });
   });
 
+  /**
+   * Tests handling of multiple concurrent calls to the `vote` function.
+   *
+   * - Verifies that the `REST.apiCal` function is called three times when multiple `vote` function calls are made concurrently.
+   */
   describe('Performance - Additional Tests', () => {
     it('should handle multiple concurrent vote calls', async () => {
       (getUserId as jest.Mock).mockResolvedValue('user123');
@@ -232,6 +353,11 @@ describe('userVote - Additional Tests', () => {
       expect(REST.apiCal).toHaveBeenCalledTimes(3);
     });
 
+    /**
+     * Tests handling of multiple concurrent calls to the `getVoteRecord` function.
+     *
+     * - Verifies that the `REST.apiCal` function is called three times when multiple `getVoteRecord` function calls are made concurrently.
+     */
     it('should handle multiple concurrent getVoteRecord calls', async () => {
       (getUserId as jest.Mock).mockResolvedValue('user123');
       (REST.apiCal as jest.Mock).mockResolvedValue({ voteData: 'someData' });
@@ -249,6 +375,13 @@ describe('userVote - Additional Tests', () => {
   });
 });
 
+/**
+ * Casts a vote for a given sequence.
+ *
+ * @param request - An object containing the sequence ID to vote on.
+ * @param type - The type of vote, either 'up' or 'down'.
+ * @returns A Promise that resolves when the vote is successfully cast.
+ */
 export const vote = async (request?: any, type?: string) => {
   let usersessionid = await getUserId();
   const payload = {
@@ -266,6 +399,12 @@ export const vote = async (request?: any, type?: string) => {
   return REST.apiCal(parameters);
 };
 
+/**
+ * Retrieves the vote record for a given sequence.
+ *
+ * @param request - An object containing the sequence ID to fetch the vote record for.
+ * @returns A Promise that resolves with the vote data for the specified sequence.
+ */
 export const getVoteRecord = async (request?: any) => {
   let userSessionId = await getUserId();
 
@@ -275,8 +414,11 @@ export const getVoteRecord = async (request?: any) => {
   };
   return REST.apiCal(parameters);
 };
-
-
+/**
+ * Mocks the REST API call functionality for testing purposes.
+ * This mock implementation replaces the actual REST.apiCal function with a Jest mock function,
+ * allowing you to assert on the calls made to the REST API during tests.
+ */
 
 jest.mock('./index', () => ({
   REST: {
@@ -284,11 +426,23 @@ jest.mock('./index', () => ({
   },
 }));
 
+/**
+ * Clears all mocks before each test in the 'userVote' test suite.
+ * This ensures that each test starts with a clean slate and can
+ * independently verify the behavior of the functions being tested.
+ */
 describe('userVote', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
+  /**
+   * Votes on a sequence with the specified type (up or down).
+   *
+   * @param request - An object containing the sequence ID to vote on.
+   * @param type - The type of vote, either 'up' or 'down'.
+   * @returns A Promise that resolves with the result of the vote operation.
+   */
   describe('vote', () => {
     it('should call REST.apiCal with the correct parameters for upvote', async () => {
       const mockUserId = 'user123';
@@ -311,6 +465,13 @@ describe('userVote', () => {
       });
     });
 
+    /**
+     * Votes on a sequence with the specified type (down).
+     *
+     * @param request - An object containing the sequence ID to vote on.
+     * @param type - The type of vote, 'down'.
+     * @returns A Promise that resolves with the result of the vote operation.
+     */
     it('should call REST.apiCal with the correct parameters for downvote', async () => {
       const mockUserId = 'user123';
       const mockRequest = { id: 'sequence123' };
@@ -332,6 +493,13 @@ describe('userVote', () => {
       });
     });
 
+    /**
+     * Votes on a sequence with the specified type (up or down).
+     *
+     * @param request - An object containing the sequence ID to vote on. If not provided, the sequence ID will be set to `undefined`.
+     * @param type - The type of vote, 'up' or 'down'. If not provided, the vote will be set to 0 for both upvote and downvote.
+     * @returns A Promise that resolves with the result of the vote operation.
+     */
     it('should call REST.apiCal with the correct parameters when type is not provided', async () => {
       const mockUserId = 'user123';
       const mockRequest = { id: 'sequence123' };
@@ -371,6 +539,10 @@ describe('userVote', () => {
 });
 
 
+/**
+ * Mocks the REST API module, providing a jest.fn() implementation of the `apiCal` function.
+ * This mock is used in the unit tests for the `userVote` service to simulate API calls.
+ */
 
 jest.mock('./index', () => ({
   REST: {
@@ -381,6 +553,14 @@ jest.mock('./index', () => ({
 describe('userVote', () => {
   // ... (previous test cases)
 
+  /**
+   * Votes on a sequence with the specified type (up or down).
+   * If no request or type is provided, it will vote with a default upvote.
+   *
+   * @param request - The request object containing the sequence ID.
+   * @param type - The type of vote, either 'up' or 'down'.
+   * @returns The result of the API call.
+   */
   describe('vote', () => {
     it('should call REST.apiCal with the correct parameters when request is not provided', async () => {
       const mockUserId = 'user123';
@@ -402,6 +582,14 @@ describe('userVote', () => {
       });
     });
 
+    /**
+     * Votes on a sequence with the specified type (up or down).
+     * If no request or type is provided, it will vote with a default upvote.
+     *
+     * @param request - The request object containing the sequence ID.
+     * @param type - The type of vote, either 'up' or 'down'.
+     * @returns The result of the API call.
+     */
     it('should call REST.apiCal with the correct parameters when request and type are not provided', async () => {
       const mockUserId = 'user123';
       (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
@@ -421,6 +609,13 @@ describe('userVote', () => {
       });
     });
 
+    /**
+     * Tests the `vote` function by calling it with a mock request and type, and verifying that the result matches the expected mock result.
+     *
+     * @param mockRequest - A mock request object containing the sequence ID.
+     * @param mockType - The type of vote, either 'up' or 'down'.
+     * @returns The result of the API call.
+     */
     it('should return the result of REST.apiCal', async () => {
       const mockUserId = 'user123';
       const mockRequest = { id: 'sequence123' };
@@ -435,6 +630,12 @@ describe('userVote', () => {
     });
   });
 
+  /**
+   * Fetches the vote record for the current user.
+   *
+   * @param request - An optional request object containing the sequence ID.
+   * @returns The vote record for the current user, including the upvote and downvote counts.
+   */
   describe('getVoteRecord', () => {
     it('should call REST.apiCal with the correct parameters when request is not provided', async () => {
       const mockUserId = 'user123';
@@ -449,6 +650,12 @@ describe('userVote', () => {
       });
     });
 
+    /**
+     * Tests the `getVoteRecord` function by calling it with a mock request and verifying that the result matches the expected mock result.
+     *
+     * @param mockRequest - An optional request object containing the sequence ID.
+     * @returns The vote record for the current user, including the upvote and downvote counts.
+     */
     it('should return the result of REST.apiCal', async () => {
       const mockUserId = 'user123';
       const mockRequest = { id: 'sequence123' };
@@ -464,17 +671,32 @@ describe('userVote', () => {
 });
 
 
+/**
+ * Mocks the `REST` module, which provides an `apiCal` function for making API calls.
+ * This mock implementation replaces the real `REST` module with a mock object that has a mocked `apiCal` function.
+ * This allows the tests to control the behavior of the `apiCal` function and verify its usage without making actual API calls.
+ */
 jest.mock('./index', () => ({
   REST: {
     apiCal: jest.fn(),
   },
 }));
 
+/**
+ * Sets up the test environment by clearing all mocks before each test.
+ * This ensures that each test starts with a clean slate and can verify
+ * the behavior of the code under test without interference from previous tests.
+ */
 describe('userVote', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
+  /**
+   * Tests the `vote` function by calling it with a mock request and verifying that the REST API is called with the correct parameters for an upvote.
+   *
+   * @param mockRequest - An optional request object containing the sequence ID.
+   */
   describe('vote', () => {
     it('should call the REST API with the correct parameters for upvote', async () => {
       const mockUserId = 'user123';
@@ -496,6 +718,11 @@ describe('userVote', () => {
       });
     });
 
+    /**
+     * Tests the `vote` function by calling it with a mock request and verifying that the REST API is called with the correct parameters for a downvote.
+     *
+     * @param mockRequest - An optional request object containing the sequence ID.
+     */
     it('should call the REST API with the correct parameters for downvote', async () => {
       const mockUserId = 'user123';
       const mockRequest = { id: 'record456' };
@@ -516,6 +743,11 @@ describe('userVote', () => {
       });
     });
 
+    /**
+     * Tests the `vote` function by calling it with a mock request and verifying that the REST API is called with the correct parameters when the request or type is missing.
+     *
+     * @param mockRequest - An optional request object containing the sequence ID.
+     */
     it('should handle missing request or type', async () => {
       const mockUserId = 'user123';
       (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
@@ -536,6 +768,11 @@ describe('userVote', () => {
     });
   });
 
+  /**
+   * Tests the `getVoteRecord` function by calling it with a mock request and verifying that the REST API is called with the correct parameters.
+   *
+   * @param mockRequest - An optional request object containing the sequence ID.
+   */
   describe('getVoteRecord', () => {
     it('should call the REST API with the correct parameters', async () => {
       const mockUserId = 'user123';
@@ -551,6 +788,11 @@ describe('userVote', () => {
       });
     });
 
+    /**
+     * Tests the `getVoteRecord` function by calling it without a request object and verifying that the REST API is called with the correct parameters.
+     *
+     * This test case ensures that the `getVoteRecord` function handles a missing request object gracefully, and that the REST API is called with the correct URL, including the user ID retrieved from the `getUserId` function.
+     */
     it('should handle missing request', async () => {
       const mockUserId = 'user123';
       (getUserId as jest.Mock).mockResolvedValueOnce(mockUserId);
@@ -567,11 +809,19 @@ describe('userVote', () => {
 });
 
 
+/**
+ * Sets up the test environment by clearing all mocks before each test.
+ */
 describe('userVote', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
+  /**
+   * Tests the `vote` function by calling it with a mock request and verifying that the REST API is called with the correct parameters when the `getUserId` function returns `null`.
+   *
+   * This test case ensures that the `vote` function handles a `null` return value from the `getUserId` function gracefully, and that the REST API is called with the correct URL and request body, including a `null` user session ID.
+   */
   describe('vote', () => {
     // Existing test cases...
 
@@ -593,6 +843,11 @@ describe('userVote', () => {
       });
       });
 
+    /**
+     * Tests the `vote` function by calling it with a mock request and an invalid type parameter, and verifying that the REST API is called with the correct parameters.
+     *
+     * This test case ensures that the `vote` function handles an invalid type parameter gracefully, and that the REST API is called with the correct URL and request body, including the user session ID and the sequence ID from the mock request.
+     */
     it('should handle invalid type parameter', async () => {
       const mockUserId = 'user123';
       const mockRequest = { id: 'record456' };
@@ -614,6 +869,11 @@ describe('userVote', () => {
     });
   });
 
+  /**
+   * Tests the `getVoteRecord` function by calling it with a mock request and a `null` return value from the `getUserId` function, and verifying that the REST API is called with the correct parameters.
+   *
+   * This test case ensures that the `getVoteRecord` function handles a `null` user session ID gracefully, and that the REST API is called with the correct URL, including the `undefined` sequence ID and the `null` user session ID.
+   */
   describe('getVoteRecord', () => {
     // Existing test cases...
 
@@ -629,6 +889,11 @@ describe('userVote', () => {
       });
     });
 
+    /**
+     * Tests the `getVoteRecord` function by calling it with a mock request that has a missing `id` property, and verifying that the REST API is called with the correct parameters.
+     *
+     * This test case ensures that the `getVoteRecord` function handles a missing `id` property in the request gracefully, and that the REST API is called with the correct URL, including the `undefined` sequence ID and the user session ID from the mock request.
+     */
     it('should handle request with missing id property', async () => {
       const mockUserId = 'user123';
       const mockRequest = {};
@@ -647,6 +912,15 @@ describe('userVote', () => {
 
 
 
+/**
+ * Tests the `vote` function by calling it with a mock request to upvote a sequence.
+ *
+ * This test case ensures that the `vote` function correctly sends a POST request to the `ENDPOINT.VoteRecord` endpoint with the expected parameters, including the user session ID and the upvote/downvote values.
+ *
+ * @param {Object} request - The request object containing the sequence ID.
+ * @param {string} type - The type of vote, either 'up' or 'down'.
+ * @returns {Promise<{ success: boolean }>} - The response from the REST API call.
+ */
 describe('userVote', () => {
   describe('vote', () => {
     it('should send an upvote request', async () => {
@@ -672,6 +946,15 @@ describe('userVote', () => {
       expect(result).toEqual({ success: true });
     });
 
+    /**
+     * Tests the `vote` function by calling it with a mock request to downvote a sequence.
+     *
+     * This test case ensures that the `vote` function correctly sends a POST request to the `ENDPOINT.VoteRecord` endpoint with the expected parameters, including the user session ID and the upvote/downvote values.
+     *
+     * @param {Object} request - The request object containing the sequence ID.
+     * @param {string} type - The type of vote, either 'up' or 'down'.
+     * @returns {Promise<{ success: boolean }>} - The response from the REST API call.
+     */
     it('should send a downvote request', async () => {
       (getUserId as jest.Mock).mockResolvedValue('user123');
       (REST.apiCal as jest.Mock).mockResolvedValue({ success: true });
@@ -695,6 +978,15 @@ describe('userVote', () => {
       expect(result).toEqual({ success: true });
     });
 
+    /**
+     * Tests the `vote` function by calling it with a mock request to upvote a sequence when the user session ID is missing.
+     *
+     * This test case ensures that the `vote` function correctly sends a POST request to the `ENDPOINT.VoteRecord` endpoint with the expected parameters, including the user session ID (which is `null` in this case) and the upvote/downvote values.
+     *
+     * @param {Object} request - The request object containing the sequence ID.
+     * @param {string} type - The type of vote, either 'up' or 'down'.
+     * @returns {Promise<{ success: boolean }>} - The response from the REST API call.
+     */
     it('should handle missing user session id', async () => {
       (getUserId as jest.Mock).mockResolvedValue(null);
       (REST.apiCal as jest.Mock).mockResolvedValue({ success: false });
@@ -719,6 +1011,14 @@ describe('userVote', () => {
     });
   });
 
+  /**
+   * Tests the `getVoteRecord` function by calling it with a mock request to fetch the vote record for a sequence.
+   *
+   * This test case ensures that the `getVoteRecord` function correctly sends a GET request to the `ENDPOINT.fetchVoteRecord` endpoint with the expected parameters, including the sequence ID and the user session ID.
+   *
+   * @param {Object} request - The request object containing the sequence ID.
+   * @returns {Promise<{ vote: string }>} - The response from the REST API call, containing the user's vote for the sequence.
+   */
   describe('getVoteRecord', () => {
     it('should fetch vote record', async () => {
       (getUserId as jest.Mock).mockResolvedValue('user123');
@@ -736,6 +1036,14 @@ describe('userVote', () => {
       expect(result).toEqual({ vote: 'up' });
     });
 
+    /**
+     * Tests the `getVoteRecord` function by calling it with a mock request to fetch the vote record for a sequence when the user session ID is missing.
+     *
+     * This test case ensures that the `getVoteRecord` function correctly sends a GET request to the `ENDPOINT.fetchVoteRecord` endpoint with the expected parameters, including the sequence ID and a null user session ID, and returns the expected response.
+     *
+     * @param {Object} request - The request object containing the sequence ID.
+     * @returns {Promise<{ vote: string }>} - The response from the REST API call, containing the user's vote for the sequence.
+     */
     it('should handle missing user session id', async () => {
       (getUserId as jest.Mock).mockResolvedValue(null);
       (REST.apiCal as jest.Mock).mockResolvedValue({ vote: 'none' });
@@ -754,6 +1062,15 @@ describe('userVote', () => {
   });
 });
 
+/**
+ * Tests the `vote` function by calling it with a mock request to send an upvote request to the API.
+ *
+ * This test case ensures that the `vote` function correctly sends a POST request to the `ENDPOINT.VoteRecord` endpoint with the expected parameters, including the sequence ID, the user session ID, and the upvote/downvote values.
+ *
+ * @param {Object} request - The request object containing the sequence ID.
+ * @param {string} type - The type of vote, either 'up' or 'down'.
+ * @returns {Promise<{ status: number }>} - The response from the REST API call, containing the status code.
+ */
 describe('userVote', () => {
     describe('vote', () => {
         it('should handle API call failure', async () => {
@@ -780,6 +1097,14 @@ describe('userVote', () => {
           });
 });
 
+/**
+ * Tests the behavior of the `getVoteRecord` function when an invalid request object is provided.
+ *
+ * This test case ensures that the `getVoteRecord` function correctly handles a request object that does not contain the expected `id` property. It verifies that the function still makes the expected API call with the `undefined` value for the sequence ID, and that the returned result matches the expected value.
+ *
+ * @param {Object} request - The request object containing the sequence ID.
+ * @returns {Promise<{ vote: string }>} - The response from the REST API call, containing the vote record.
+ */
 describe('getVoteRecord', () => {
     
   it('should handle invalid request object', async () => {
@@ -801,12 +1126,24 @@ describe('getVoteRecord', () => {
 
   
 
+/**
+ * Sets up the test environment for the `userVote` module by resetting the mocks for the `getUserId` and `REST.apiCal` functions.
+ * 
+ * This `beforeEach` block is executed before each test in the `userVote` test suite, ensuring that the mocks are in a known state before each test is run.
+ */
 describe('userVote', () => {
   beforeEach(() => {
     (getUserId as jest.Mock).mockReset();
     (REST.apiCal as jest.Mock).mockReset();
   });
 
+  /**
+   * Sends a vote request to the server, either an upvote or a downvote.
+   *
+   * @param {Object} request - The request object containing the sequence ID.
+   * @param {'up'|'down'} voteType - The type of vote to send, either 'up' or 'down'.
+   * @returns {Promise<{ status: number }>} - The response from the REST API call, containing the status code.
+   */
   describe('vote', () => {
     it('should send an upvote request', async () => {
       (getUserId as jest.Mock).mockResolvedValue('user123');
@@ -850,6 +1187,13 @@ describe('userVote', () => {
   });
 
   describe('getVoteRecord', () => {
+    /**
+     * Fetches the vote record for a given sequence ID and user session ID.
+     *
+     * @param {Object} request - The request object containing the sequence ID.
+     * @param {string} request.id - The ID of the sequence to fetch the vote record for.
+     * @returns {Promise<{ data: any }>} - The response from the REST API call, containing the vote data.
+     */
     it('should fetch the vote record', async () => {
       (getUserId as jest.Mock).mockResolvedValue('user123');
       (REST.apiCal as jest.Mock).mockResolvedValue({ data: 'voteData' });
@@ -867,6 +1211,9 @@ describe('userVote', () => {
 });
 
 
+/**
+ * Sets up the test environment for the `userVote` module by resetting the mocks for the `getUserId` and `REST.apiCal` functions before each test.
+ */
 
 describe('userVote', () => {
   beforeEach(() => {
@@ -876,6 +1223,13 @@ describe('userVote', () => {
 });
 
   describe('vote', () => {
+    /**
+     * Sends an upvote request to the server for the specified sequence ID.
+     *
+     * @param {Object} request - The request object containing the sequence ID.
+     * @param {string} request.id - The ID of the sequence to upvote.
+     * @returns {Promise<{ status: number }>} - The response from the REST API call, containing the status code.
+     */
     it('should send an upvote request', async () => {
       (getUserId as jest.Mock).mockResolvedValue('user123');
       (REST.apiCal as jest.Mock).mockResolvedValue({ status: 200 });
@@ -895,14 +1249,13 @@ describe('userVote', () => {
       });
       expect(result).toEqual({ status: 200 });
     });
-
-
-      const result = await vote({ id: 'sequence101112' }, 'down');
-
-      expect(getUserId).toHaveBeenCalled();
-      expe
     
 
+    /**
+     * Handles errors that occur when trying to get the user ID for a vote request.
+     *
+     * This test case verifies that if the `getUserId` function rejects with an error, the `vote` function will also reject with the same error, and the `REST.apiCal` function will not be called.
+     */
     it('should handle errors from getUserId', async () => {
       (getUserId as jest.Mock).mockRejectedValue(new Error('Failed to get user ID'));
 
@@ -910,6 +1263,15 @@ describe('userVote', () => {
       expect(REST.apiCal).not.toHaveBeenCalled();
     });
 
+    /**
+     * Handles errors that occur when the REST API call fails during a vote request.
+     *
+     * This test case verifies that if the `REST.apiCal` function rejects with an error, the `vote` function will also reject with the same error, and the `getUserId` function will still be called.
+     *
+     * @param {Object} request - The request object containing the sequence ID.
+     * @param {string} request.id - The ID of the sequence to vote on.
+     * @returns {Promise<void>} - Rejects with the error thrown by the `REST.apiCal` function.
+     */
     it('should handle errors from REST.apiCal', async () => {
       (getUserId as jest.Mock).mockResolvedValue('user123');
       (REST.apiCal as jest.Mock).mockRejectedValue(new Error('API request failed'));
@@ -917,29 +1279,18 @@ describe('userVote', () => {
       await expect(vote({ id: 'sequence456' }, 'up')).rejects.toThrow('API request failed');
       expect(getUserId).toHaveBeenCalled();
     });
-
-    it('should send a request with upvote: 0 and downvote: 0 if type is not provided', async () => {
-      (getUserId as jest.Mock).mockResolvedValue('user123');
-      (REST.apiCal as jest.Mock).mockResolvedValue({ status: 200 });
-
-      const result = await vote({ id: 'sequence456' });
-
-      expect(getUserId).toHaveBeenCalled();
-      expect(REST.apiCal).toHaveBeenCalledWith({
-        url: ENDPOINT.VoteRecord,
-        method: 'POST',
-        body: {
-          usersessionid: 'user123',
-          sequenceid: 'sequence456',
-          upvote: 0,
-          downvote: 0,
-        },
-      });
-      expect(result).toEqual({ status: 200 });
-    });
   });
 
   describe('getVoteRecord', () => {
+    /**
+     * Fetches the vote record for a given sequence ID and user session ID.
+     *
+     * This function makes a GET request to the `ENDPOINT.fetchVoteRecord` endpoint, passing the sequence ID and user session ID as URL parameters. It returns the response data from the API call.
+     *
+     * @param {Object} request - The request object containing the sequence ID.
+     * @param {string} request.id - The ID of the sequence to fetch the vote record for.
+     * @returns {Promise<Object>} - The response data from the API call.
+     */
     it('should fetch the vote record', async () => {
       (getUserId as jest.Mock).mockResolvedValue('user123');
       (REST.apiCal as jest.Mock).mockResolvedValue({ data: 'voteData' });
@@ -955,6 +1306,15 @@ describe('userVote', () => {
     });
 });
 
+    /**
+     * Handles errors that occur when the `getUserId` function fails to retrieve the user ID.
+     *
+     * This test case verifies that if the `getUserId` function rejects with an error, the `getVoteRecord` function will also reject with the same error, and the `REST.apiCal` function will not be called.
+     *
+     * @param {Object} request - The request object containing the sequence ID.
+     * @param {string} request.id - The ID of the sequence to fetch the vote record for.
+     * @returns {Promise<void>} - Rejects with the error thrown by the `getUserId` function.
+     */
     it('should handle errors from getUserId', async () => {
       (getUserId as jest.Mock).mockRejectedValue(new Error('Failed to get user ID'));
 
@@ -963,15 +1323,34 @@ describe('userVote', () => {
     });
 
 
+/**
+ * Mocks the `./userService` and `./index` modules for testing purposes.
+ * This allows the tests to control the behavior of these modules and verify the expected interactions.
+ */
 jest.mock('./userService');
 jest.mock('./index');
 
+/**
+ * Sets up the test environment for the `vote` function by mocking the `getUserId` and `REST.apiCal` functions.
+ *
+ * This `beforeEach` block is executed before each test in the `vote` test suite. It ensures that the `getUserId` function returns a mock user ID of `'user123'`, and the `REST.apiCal` function returns a mock response with `{ success: true }`.
+ */
 describe('vote', () => {
   beforeEach(() => {
     getUserId.mockResolvedValue('user123');
     REST.apiCal.mockResolvedValue({ success: true });
   });
 
+  /**
+   * Sends a POST request to the vote record endpoint with the appropriate parameters for an upvote.
+   *
+   * This test case verifies that the `vote` function correctly sends a POST request to the `ENDPOINT.VoteRecord` endpoint with the expected parameters when the `type` parameter is set to `'up'`.
+   *
+   * @param {Object} request - The request object containing the sequence ID.
+   * @param {string} request.id - The ID of the sequence to vote on.
+   * @param {string} type - The type of vote, either `'up'` or `'down'`.
+   * @returns {Promise<void>} - Resolves when the API call is complete.
+   */
   it('should send a POST request with correct parameters for upvote', async () => {
     const request = { id: 'seq123' };
     const type = 'up';
@@ -988,6 +1367,16 @@ describe('vote', () => {
     });
   });
 
+  /**
+   * Sends a POST request to the vote record endpoint with the appropriate parameters for a downvote.
+   *
+   * This test case verifies that the `vote` function correctly sends a POST request to the `ENDPOINT.VoteRecord` endpoint with the expected parameters when the `type` parameter is set to `'down'`.
+   *
+   * @param {Object} request - The request object containing the sequence ID.
+   * @param {string} request.id - The ID of the sequence to vote on.
+   * @param {string} type - The type of vote, either `'up'` or `'down'`.
+   * @returns {Promise<void>} - Resolves when the API call is complete.
+   */
   it('should send a POST request with correct parameters for downvote', async () => {
     const request = { id: 'seq123' };
     const type = 'down';
@@ -1004,6 +1393,16 @@ describe('vote', () => {
     });
   });
 
+  /**
+   * Verifies that the `vote` function gracefully handles a null userId when sending a POST request to the `ENDPOINT.VoteRecord` endpoint.
+   *
+   * This test case checks that the `vote` function does not make an API call if the `getUserId` function returns a null userId.
+   *
+   * @param {Object} request - The request object containing the sequence ID.
+   * @param {string} request.id - The ID of the sequence to vote on.
+   * @param {string} type - The type of vote, either `'up'` or `'down'`.
+   * @returns {Promise<void>} - Resolves when the test case is complete.
+   */
   it('should handle null userId gracefully', async () => {
     getUserId.mockResolvedValue(null);
     const request = { id: 'seq123' };
@@ -1014,12 +1413,31 @@ describe('vote', () => {
 });
 
 describe('vote', () => {
+    /**
+     * Verifies that the `vote` function does not make an API call if the `request` parameter is `undefined`.
+     *
+     * This test case checks that the `vote` function gracefully handles the case where the `request` parameter is `undefined` by not making an API call.
+     *
+     * @param {Object|undefined} request - The request object containing the sequence ID. If `undefined`, the function should not make an API call.
+     * @param {string} type - The type of vote, either `'up'` or `'down'`.
+     * @returns {Promise<void>} - Resolves when the test case is complete.
+     */
     it('should not send a request if request object is undefined', async () => {
       const type = 'up';
       await vote(undefined, type);
       expect(REST.apiCal).not.toHaveBeenCalled();
     });
   
+    /**
+     * Verifies that the `vote` function does not make an API call if the `type` parameter is neither `'up'` nor `'down'`.
+     *
+     * This test case checks that the `vote` function gracefully handles the case where the `type` parameter is an invalid value by not making an API call.
+     *
+     * @param {Object} request - The request object containing the sequence ID.
+     * @param {string} request.id - The ID of the sequence to vote on.
+     * @param {string} type - The type of vote, which should be either `'up'` or `'down'`.
+     * @returns {Promise<void>} - Resolves when the test case is complete.
+     */
     it('should not send a request if type is neither "up" nor "down"', async () => {
       const request = { id: 'seq123' };
       const type = 'invalidType';
@@ -1027,6 +1445,16 @@ describe('vote', () => {
       expect(REST.apiCal).not.toHaveBeenCalled();
     });
   
+    /**
+     * Verifies that the `vote` function gracefully handles API call failures by rejecting the promise with the error message.
+     *
+     * This test case checks that if the `REST.apiCal` function throws an error, the `vote` function will reject the promise with the same error message.
+     *
+     * @param {Object} request - The request object containing the sequence ID.
+     * @param {string} request.id - The ID of the sequence to vote on.
+     * @param {string} type - The type of vote, either `'up'` or `'down'`.
+     * @returns {Promise<void>} - Rejects with the error message when the API call fails.
+     */
     it('should handle API call failures gracefully', async () => {
       REST.apiCal.mockRejectedValue(new Error('API call failed'));
       const request = { id: 'seq123' };
@@ -1037,27 +1465,69 @@ describe('vote', () => {
 
 
 
+/**
+ * Mocks the `REST.apiCal` function from the `./index` module for testing purposes.
+ * This allows the tests to control the behavior of the `REST.apiCal` function without making actual API calls.
+ */
 jest.mock('./index', () => ({
   REST: {
     apiCal: jest.fn()
   }
 }));
 
+/**
+ * Describes the test suite for the `vote` function.
+ * 
+ * This test suite verifies the behavior of the `vote` function, which is responsible for sending a vote request to the server.
+ * The tests cover different scenarios, such as sending a valid vote request, handling invalid vote types, and gracefully handling API call failures.
+ */
 describe('vote', () => {
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  
-
-  
+  });  
 });
 
+/**
+ * Clears all mocks after each test in the `getVoteRecord` test suite.
+ * This ensures that each test starts with a clean slate and doesn't interfere with other tests.
+ */
+afterEach(() => {
+  jest.clearAllMocks();
+});
 describe('getVoteRecord', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
+  /**
+   * Tests the `getVoteRecord` function by mocking the `REST.apiCal` function and verifying that it is called with the correct parameters.
+   *
+   * @param {Object} mockRequest - The mock request object containing the sequence ID.
+   * @param {string} mockRequest.id - The ID of the sequence to fetch the vote record for.
+   * @returns {Promise<void>} - Resolves when the test completes successfully.
+   */
+  it('should call the fetch vote record API with the correct parameters', async () => {
+    const mockRequest = {
+      id: 'sequence-123'
+    };
+  
+    jest.spyOn(global, 'getUserId').mockResolvedValue('user-123');
+  
+    await getVoteRecord(mockRequest);
+  
+    expect(getUserId).toHaveBeenCalled();
+    expect(REST.apiCal).toHaveBeenCalledWith({
+      url: `${ENDPOINT.fetchVoteRecord}sequence-123/user-123`,
+      method: 'GET'
+    });
+  });
+  /**
+   * Tests the `getVoteRecord` function by mocking the `REST.apiCal` function and verifying that it is called with the correct parameters.
+   *
+   * @param {Object} mockRequest - The mock request object containing the sequence ID.
+   * @param {string} mockRequest.id - The ID of the sequence to fetch the vote record for.
+   * @returns {Promise<void>} - Resolves when the test completes successfully.
+   */
   it('should call the fetch vote record API with the correct parameters', async () => {
     const mockRequest = {
       id: 'sequence-123'
@@ -1076,17 +1546,32 @@ describe('getVoteRecord', () => {
 });
 
 
+/**
+ * Mocks the `REST.apiCal` function from the `./index` module for testing purposes.
+ */
 jest.mock('./index', () => ({
   REST: {
     apiCal: jest.fn()
   }
 }));
 
+/**
+ * Clears all mocks after each test in the 'vote' suite.
+ * This ensures that each test starts with a clean slate and
+ * doesn't have any side effects from previous tests.
+ */
 describe('vote', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
+  /**
+   * Tests the `vote` function by mocking the `getUserId` and `REST.apiCal` functions and verifying that the vote API is called with the correct payload for an upvote.
+   *
+   * @param {Object} mockRequest - The mock request object containing the sequence ID.
+   * @param {string} mockRequest.id - The ID of the sequence to vote on.
+   * @returns {Promise<void>} - Resolves when the test completes successfully.
+   */
   it('should call the vote API with the correct payload for an upvote', async () => {
     const mockRequest = {
       id: 'sequence-123'
@@ -1109,6 +1594,13 @@ describe('vote', () => {
     });
   });
 
+  /**
+   * Tests the `vote` function by mocking the `getUserId` and `REST.apiCal` functions and verifying that the vote API is called with the correct payload for a downvote.
+   *
+   * @param {Object} mockRequest - The mock request object containing the sequence ID.
+   * @param {string} mockRequest.id - The ID of the sequence to vote on.
+   * @returns {Promise<void>} - Resolves when the test completes successfully.
+   */
   it('should call the vote API with the correct payload for a downvote', async () => {
     const mockRequest = {
       id: 'sequence-123'
@@ -1131,6 +1623,13 @@ describe('vote', () => {
     });
   });
 
+  /**
+   * Tests the `vote` function by mocking the `getUserId` and `REST.apiCal` functions and verifying that the vote API is called with the correct payload for an upvote, and that the result of the API call is returned.
+   *
+   * @param {Object} mockRequest - The mock request object containing the sequence ID.
+   * @param {string} mockRequest.id - The ID of the sequence to vote on.
+   * @returns {Promise<Object>} - Resolves with the response from the vote API call.
+   */
   it('should return the result of the API call', async () => {
     const mockRequest = {
       id: 'sequence-123'
@@ -1144,6 +1643,13 @@ describe('vote', () => {
     expect(result).toEqual(mockResponse);
   });
 
+  /**
+   * Tests the `vote` function by mocking the `getUserId` and `REST.apiCal` functions and verifying that the vote API is called with the correct payload for an upvote, and that the error is thrown if the API call fails.
+   *
+   * @param {Object} mockRequest - The mock request object containing the sequence ID.
+   * @param {string} mockRequest.id - The ID of the sequence to vote on.
+   * @returns {Promise<void>} - Resolves when the test completes successfully, or rejects with the error if the API call fails.
+   */
   it('should throw an error if the API call fails', async () => {
     const mockRequest = {
       id: 'sequence-123'
@@ -1157,14 +1663,14 @@ describe('vote', () => {
   });
 });
 
+/**
+ * Clears all mocks after each test in the `getVoteRecord` suite.
+ */
 describe('getVoteRecord', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 });
-
-  
-
 
 it('should upvote a recording', async () => {
     const request = { id: 'recording-123' };
@@ -1239,6 +1745,12 @@ it('should upvote a recording', async () => {
       method: 'GET'
     });
   });
+/**
+ * Throws an error if the provided request object does not have an 'id' property.
+ *
+ * @param {Object} request - The request object containing the recording ID.
+ * @throws {Error} If the request ID is not provided.
+ */
 
   it('should not vote and throw an error when request ID is not provided', async () => {
     const request = { id: null };
@@ -1247,6 +1759,13 @@ it('should upvote a recording', async () => {
     await expect(vote(request, type)).rejects.toThrow('Request ID is required');
   });
   
+  /**
+   * Throws an error if the provided vote type is neither "up" nor "down".
+   *
+   * @param {Object} request - The request object containing the recording ID.
+   * @param {string} type - The type of vote, either "up" or "down".
+   * @throws {Error} If the vote type is invalid.
+   */
   it('should not vote and throw an error when type is neither "up" nor "down"', async () => {
     const request = { id: 'recording-123' };
     const type = 'invalid';
@@ -1254,6 +1773,12 @@ it('should upvote a recording', async () => {
     await expect(vote(request, type)).rejects.toThrow('Invalid vote type');
   });
   
+  /**
+   * Throws an error if the provided request object does not have an 'id' property.
+   *
+   * @param {Object} request - The request object containing the recording ID.
+   * @throws {Error} If the request ID is not provided.
+   */
   it('should not fetch vote record and throw an error when request ID is not provided', async () => {
     const request = { id: null };
   
@@ -1279,17 +1804,29 @@ it('should upvote a recording', async () => {
   
   
   
+  /**
+   * Mocks the REST.apiCal function from the './index' module for testing purposes.
+   */
   jest.mock('./index', () => ({
     REST: {
       apiCal: jest.fn()
     }
   }));
   
+  /**
+   * Clears all mocks after each test in the 'vote' suite.
+   */
   describe('vote', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });
   
+    /**
+     * Calls the REST.apiCal function with the correct parameters to record an upvote for the specified request.
+     *
+     * @param {Object} request - The request object containing the recording ID.
+     * @returns {Promise<void>} - A Promise that resolves when the upvote is recorded.
+     */
     it('should call REST.apiCal with the correct parameters for an upvote', async () => {
       const mockUserId = '123456789';
       const mockRequest = { id: 'abc123' };
@@ -1310,6 +1847,12 @@ it('should upvote a recording', async () => {
       });
     });
   
+    /**
+     * Calls the REST.apiCal function with the correct parameters to record a downvote for the specified request.
+     *
+     * @param {Object} request - The request object containing the recording ID.
+     * @returns {Promise<void>} - A Promise that resolves when the downvote is recorded.
+     */
     it('should call REST.apiCal with the correct parameters for a downvote', async () => {
       const mockUserId = '123456789';
       const mockRequest = { id: 'abc123' };
@@ -1330,6 +1873,12 @@ it('should upvote a recording', async () => {
       });
     });
   
+    /**
+     * Calls the REST.apiCal function with the correct parameters to record a neutral vote for the specified request.
+     *
+     * @param {Object} request - The request object containing the recording ID.
+     * @returns {Promise<void>} - A Promise that resolves when the neutral vote is recorded.
+     */
     it('should call REST.apiCal with the correct parameters for a neutral vote', async () => {
       const mockUserId = '123456789';
       const mockRequest = { id: 'abc123' };
@@ -1351,11 +1900,20 @@ it('should upvote a recording', async () => {
     });
   });
   
+  /**
+   * Clears all mocks after each test in the 'getVoteRecord' test suite.
+   */
   describe('getVoteRecord', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });
   
+    /**
+     * Calls the REST.apiCal function with the correct parameters to fetch the vote record for the specified request and user.
+     *
+     * @param {Object} request - The request object containing the recording ID.
+     * @returns {Promise<void>} - A Promise that resolves when the vote record is fetched.
+     */
     it('should call REST.apiCal with the correct parameters', async () => {
       const mockUserId = '123456789';
       const mockRequest = { id: 'abc123' };
@@ -1372,11 +1930,20 @@ it('should upvote a recording', async () => {
   });
 
 
+/**
+ * Clears all mocks after each test in the 'vote' test suite.
+ */
 describe('vote', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
+  /**
+   * Calls the REST.apiCal function with the correct parameters to record an upvote for the specified request and user.
+   *
+   * @param {Object} request - The request object containing the recording ID.
+   * @returns {Promise<void>} - A Promise that resolves when the upvote is recorded.
+   */
   it('should call REST.apiCal with the correct parameters for an upvote', async () => {
     const mockUserId = '123456789';
     const mockRequest = { id: 'abc123' };
@@ -1397,6 +1964,12 @@ describe('vote', () => {
     });
   });
 
+  /**
+   * Calls the REST.apiCal function with the correct parameters to record a downvote for the specified request and user.
+   *
+   * @param {Object} request - The request object containing the recording ID.
+   * @returns {Promise<void>} - A Promise that resolves when the downvote is recorded.
+   */
   it('should call REST.apiCal with the correct parameters for a downvote', async () => {
     const mockUserId = '123456789';
     const mockRequest = { id: 'abc123' };
@@ -1417,6 +1990,12 @@ describe('vote', () => {
     });
   });
 
+  /**
+   * Calls the REST.apiCal function with the correct parameters to record a neutral vote for the specified request and user.
+   *
+   * @param {Object} request - The request object containing the recording ID.
+   * @returns {Promise<void>} - A Promise that resolves when the neutral vote is recorded.
+   */
   it('should call REST.apiCal with the correct parameters for a neutral vote', async () => {
     const mockUserId = '123456789';
     const mockRequest = { id: 'abc123' };
@@ -1437,6 +2016,12 @@ describe('vote', () => {
     });
   });
 
+  /**
+   * Handles the case where a null request is passed to the `vote` function.
+   *
+   * @param {Object} request - The request object containing the recording ID.
+   * @returns {Promise<void>} - A Promise that resolves when the vote is recorded.
+   */
   it('should handle null request', async () => {
     const mockUserId = '123456789';
 
@@ -1447,6 +2032,13 @@ describe('vote', () => {
     expect(REST.apiCal).not.toHaveBeenCalled();
   });
 
+  /**
+   * Handles the case where an invalid vote type is passed to the `vote` function.
+   *
+   * @param {Object} request - The request object containing the recording ID.
+   * @param {string} voteType - The type of vote to record ('up', 'down', or 'invalid').
+   * @returns {Promise<void>} - A Promise that resolves when the vote is recorded.
+   */
   it('should handle invalid vote type', async () => {
     const mockUserId = '123456789';
     const mockRequest = { id: 'abc123' };
@@ -1468,11 +2060,20 @@ describe('vote', () => {
   });
 });
 
+/**
+ * Clears all mocks after each test in the `getVoteRecord` suite.
+ */
 describe('getVoteRecord', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
+  /**
+   * Calls the REST API to fetch the vote record for a given request.
+   *
+   * @param {Object} request - The request object containing the recording ID.
+   * @returns {Promise<void>} - A Promise that resolves when the vote record is fetched.
+   */
   it('should call REST.apiCal with the correct parameters', async () => {
     const mockUserId = '123456789';
     const mockRequest = { id: 'abc123' };
@@ -1487,6 +2088,11 @@ describe('getVoteRecord', () => {
     });
   });
 
+  /**
+   * Handles the case where a null request is passed to the `getVoteRecord` function.
+   *
+   * This test ensures that the `getVoteRecord` function does not make any API calls when a null request is provided.
+   */
   it('should handle null request', async () => {
     const mockUserId = '123456789';
 

--- a/src/services/userVote.ts
+++ b/src/services/userVote.ts
@@ -3,12 +3,6 @@ import { ENDPOINT } from "../config/endpoints";
 import { REST } from "./index";
 import { UDAErrorLogger } from "../config/error-log";
 
-/**
- * To vote/de-vote the recording
- * @param request
- * @param type
- * @returns promise
- */
 export const vote = async (request?: any, type?: string): Promise<any> => {
   try {
     if (!request || !request.id) {

--- a/src/services/userVote.ts
+++ b/src/services/userVote.ts
@@ -3,8 +3,19 @@ import { ENDPOINT } from "../config/endpoints";
 import { REST } from "./index";
 import { UDAErrorLogger } from "../config/error-log";
 
+/**
+ * Submits a vote for a given request.
+ *
+ * @param request - An object containing the request ID.
+ * @param type - The type of vote, either "up" or "down".
+ * @returns A Promise that resolves to the response from the server.
+ * @throws {Error} If the request is missing an ID or the vote type is invalid.
+ * @throws {Error} If the user session ID is not found.
+ * @throws {Error} If no response is received from the server.
+ */
 export const vote = async (request?: any, type?: string): Promise<any> => {
   try {
+    // Validate request and vote type
     if (!request || !request.id) {
       throw new Error("Invalid request: missing id");
     }
@@ -12,11 +23,13 @@ export const vote = async (request?: any, type?: string): Promise<any> => {
       throw new Error("Invalid vote type: must be 'up' or 'down'");
     }
 
+    // Get user session ID
     const usersessionid = await getUserId();
     if (!usersessionid) {
       throw new Error("User session ID not found");
     }
 
+    // Prepare payload for the API call
     const payload = {
       usersessionid,
       sequenceid: request.id,
@@ -24,18 +37,21 @@ export const vote = async (request?: any, type?: string): Promise<any> => {
       downvote: type === "down" ? 1 : 0,
     };
 
+    // Set up parameters for the API call
     const parameters = {
       url: ENDPOINT.VoteRecord,
       method: "POST",
       body: payload,
     };
 
+    // Make the API call
     const response = await REST.apiCal(parameters);
     if (!response) {
       throw new Error("No response received from the server");
     }
     return response;
   } catch (error) {
+    // Log the error and re-throw it
     UDAErrorLogger.error("Error in vote function", error);
     throw error;
   }
@@ -43,26 +59,31 @@ export const vote = async (request?: any, type?: string): Promise<any> => {
 
 export const getVoteRecord = async (request?: any): Promise<any> => {
   try {
+    // Validate request
     if (!request || !request.id) {
       throw new Error("Invalid request: missing id");
     }
 
+    // Get user session ID
     const userSessionId = await getUserId();
     if (!userSessionId) {
       throw new Error("User session ID not found");
     }
 
+    // Set up parameters for the API call
     const parameters = {
       url: `${ENDPOINT.fetchVoteRecord}${request.id}/${userSessionId}`,
       method: "GET"
     };
 
+    // Make the API call
     const response = await REST.apiCal(parameters);
     if (!response) {
       throw new Error("No response received from the server");
     }
     return response;
   } catch (error) {
+    // Log the error and re-throw it
     UDAErrorLogger.error("Error in getVoteRecord function", error);
     throw error;
   }


### PR DESCRIPTION
test(searchService): Add unit tests for searchService module

- Add test suite for fetchSearchResults function
  - Test case to verify REST.apiCal is called with correct parameters including additionalParams
  - Test case to verify REST.apiCal is called with correct parameters without additionalParams
  - Test case to verify recordUserClickData is called with correct parameters
- Add test suite for fetchRecord function
  - Test case to verify REST.apiCal is called with correct parameters
  - Test case to verify REST.apiCal is called with correct parameters without additionalParams
- Add test suite for fetchSpecialNodes function
  - Test case to verify fetchSpecialNodes returns the specialNodes object
- Set up mocking for userService, index, and recordService modules
- Clear all mocks after each test suite
